### PR TITLE
Prep for 2.3.0 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,13 @@
+# IZ Gateway Release 2.3.0
+The IZ Gateway Hub 2.3.0 release
+* IGDD-1988 - Adding logic to provide a way to bypass the SecretHeaderFilter if the request URI matches one of the configured paths.  This is useful for healthchecks that cannot attach an http header with the secret.
+* IGDD-1986 Fix to TLS test issue when IZG Hub pipeline runs.
+* IGDD-2006 Address two HIGH CVE's before 2.3.0 release - CVE-2025-22235, CVE-2025-30706
+
+# IZ Gateway Release 2.2.2
+The IZ Gateway Hub 2.2.2 release
+* IGDD-1962 Fix for CVE-2025-22228. Description of the CVE that is being fixed: BCryptPasswordEncoder.matches(CharSequence,String) will incorrectly return true for passwords larger than 72 characters as long as the first 72 characters are the same.
+
 # IZ Gateway Release 2.2.1
 The IZ Gateway Hub 2.2.1 release
 * IGDD-1934 Add support for Measles reporting to ADS

--- a/docs/release/RELEASE_NOTES.md
+++ b/docs/release/RELEASE_NOTES.md
@@ -1,12 +1,4 @@
-# IZ Gateway Release 2.2.1
-The IZ Gateway Hub 2.2.1 release
-* IGDD-1934 Add support for Measles reporting to ADS
-* IGDD-1938 Circuit Breakers are Not Being Reset
-    - Improve throw and reset logic for circuit breakers
-    - Add /rest/reset API on a single host
-    - Add ?reset=true parameter on /rest/refresh API to enable a reset during a refresh on all hosts
-  
-* IGDD-1942 Address CVE-2025-24813 in IZG Hub
-    - Upgraded to spring-boot 3.4.3
-  
+# IZ Gateway Release 2.2.2
+The IZ Gateway Hub 2.2.2 release
+* IGDD-1962 Fix for CVE-2025-22228. Description of the CVE that is being fixed: BCryptPasswordEncoder.matches(CharSequence,String) will incorrectly return true for passwords larger than 72 characters as long as the first 72 characters are the same.
 


### PR DESCRIPTION
Prepping for the release.  Ensuring develop branch has changes from main branch - this step should have been done during the 2.2.2 release process.  

Merging main into develop to take release notes from 2.2.2.  Also updating the release notes for 2.3.0