### PR TITLE
Merging IGDD-2092 into release branch 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+# IZ Gateway Release 2.4.1
+* IGDD-2092 Bumping spring boot to 3.4.7 to address CVE-2025-49125 (embedded Tomcat will now be at version 10.1.42 to resolve the CVE)
+
 # IZ Gateway Release 2.4.0
 * IGDD-2002 Added PUT and DELETE operations on MessageHeader
 * IGDD-1989 Add ADS Support for Test File Marking in Metadata

--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,6 @@
 			<artifactId>HikariCP</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-			<version>1.5</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>[2.15.0,)</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
 	</parent>
 	<groupId>gov.cdc.izgw</groupId>
 	<artifactId>izgw-hub</artifactId>
-	<version>2.4.0-IZGW-RELEASE</version>
+	<version>2.4.1-IZGW-RELEASE</version>
 	<packaging>jar</packaging>
-	<name>IZ Gateway Hub 2.4.0</name>
+	<name>IZ Gateway Hub 2.4.1</name>
 	<description>IZ Gateway Hub</description>
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.6</version>
+		<version>3.4.7</version>
 		<relativePath />
 	</parent>
 	<groupId>gov.cdc.izgw</groupId>


### PR DESCRIPTION
Bumping spring boot version to 3.4.7 to address tomcat CVE.  This will upgrade Tomcat to 10.1.42.