### PR TITLE
IGDD-2093 - Update to use dynamodb table name from DynamoDbConfig

### DIFF
--- a/src/main/java/gov/cdc/izgateway/dynamodb/DynamoDbRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/DynamoDbRepository.java
@@ -29,7 +29,6 @@ public class DynamoDbRepository<T extends DynamoDbEntity> {
 	 * The table name for the repository of entities.  Because we are using a single table 
 	 * design, there is only one table name.
 	 */
-	public static final String TABLE_NAME = "izgw-hub";
 	private final Class<T> entityClass;
 	private final DynamoDbTable<T> table;
 	
@@ -38,11 +37,11 @@ public class DynamoDbRepository<T extends DynamoDbEntity> {
 	 * @param entityClass	The class representing the entity to create the repository for.
 	 * @param client	The DynamoDbEnhancedClient to use to create the repository.
 	 */
-	public DynamoDbRepository(Class<T> entityClass, DynamoDbEnhancedClient client) {
+	public DynamoDbRepository(Class<T> entityClass, DynamoDbEnhancedClient client, String tableName) {
 		this.entityClass = entityClass;
 		// This creates the schema from the class, but does not get subclass attributes.
 		BeanTableSchema<T> schema = TableSchema.fromBean(entityClass);
-		table = client.table(TABLE_NAME, schema);
+		table = client.table(tableName, schema);
 		log.info("Table initialized for {}", entityClass.getSimpleName());
 	}
 	

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/AccessControlRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/AccessControlRepository.java
@@ -18,8 +18,8 @@ public class AccessControlRepository extends DynamoDbRepository<AccessControl> i
 	 * Construct a new AccessControlRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public AccessControlRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(AccessControl.class, client);
+	public AccessControlRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(AccessControl.class, client, tableName);
 	}
 	
 	@Override

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/CertificateStatusRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/CertificateStatusRepository.java
@@ -17,8 +17,8 @@ public class CertificateStatusRepository extends DynamoDbRepository<CertificateS
 	 * Construct a new CertificateStatusRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public CertificateStatusRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(CertificateStatus.class, client);
+	public CertificateStatusRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(CertificateStatus.class, client, tableName);
 	}
 	
 	@Override

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/DestinationRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/DestinationRepository.java
@@ -19,8 +19,8 @@ public class DestinationRepository extends DynamoDbRepository<Destination> imple
 	 * Construct a new DestinationRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public DestinationRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(Destination.class, client);
+	public DestinationRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(Destination.class, client, tableName);
 	}
 	
 	@Override

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/EndpointStatusRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/EndpointStatusRepository.java
@@ -31,8 +31,8 @@ public class EndpointStatusRepository extends DynamoDbRepository<EndpointStatus>
 	 * Construct a new EndpointStatusRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public EndpointStatusRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(EndpointStatus.class, client);
+	public EndpointStatusRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(EndpointStatus.class, client, tableName);
 	}
 	
 	@Override

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/EventRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/EventRepository.java
@@ -20,8 +20,8 @@ public class EventRepository extends DynamoDbRepository<Event> {
 	 * Construct a new JurisdictionRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public EventRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(Event.class, client);
+	public EventRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(Event.class, client, tableName);
 	}
 	
 	/**

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/JurisdictionRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/JurisdictionRepository.java
@@ -17,8 +17,8 @@ public class JurisdictionRepository extends DynamoDbRepository<Jurisdiction> imp
 	 * Construct a new JurisdictionRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public JurisdictionRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(Jurisdiction.class, client);
+	public JurisdictionRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(Jurisdiction.class, client, tableName);
 	}
 	
 	@Override

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/MessageHeaderRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/MessageHeaderRepository.java
@@ -17,8 +17,8 @@ public class MessageHeaderRepository extends DynamoDbRepository<MessageHeader> i
 	 * Construct a new JurisdictionRepository from the DynamoDb enhanced client.
 	 * @param client The client
 	 */
-	public MessageHeaderRepository(@Autowired DynamoDbEnhancedClient client) {
-		super(MessageHeader.class, client);
+	public MessageHeaderRepository(@Autowired DynamoDbEnhancedClient client, String tableName) {
+		super(MessageHeader.class, client, tableName);
 	}
 	
 	@Override


### PR DESCRIPTION
Update DynamoDbRepository and DynamoDbRepositoryFactory to use the table name from DynamoDbConfig so that setting AMAZON_DYNAMODB_TABLE will be used.

Definition of Done
- [ ] CI/CD Is passing
- [ ] There is either a Unit or Integration Test in CI/CD
- [ ] Acceptance Criteria is Met
- [ ] Code adheres to Team Coding Standards
- [ ] No Major Code Smells
- [ ] No Security Findings (check image in ECR, and Dependency Check Report in CD/CD)
- [ ] Release Notes are updated noting the fix 