### PR TITLE
IGDD-2181 - Update APHL ECR location and image name

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -460,6 +460,6 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.APHL_ECR_REPOSITORY }}
           IMAGE_TAG: ${{needs.build.outputs.image_tag}}
         run: |
-          echo "About to push image to APHL ECR image tag: ${IMAGE_TAG}"
-          docker image tag iz-gateway:${IMAGE_TAG} $ECR_REGISTRY/$ECR_REPOSITORY:iz-gateway_${IMAGE_TAG}
+          echo "About to push image to APHL ECR: izgw-hub-${{env.VERSION}}_${{github.run_number}}"
+          docker image tag iz-gateway:${IMAGE_TAG} $ECR_REGISTRY/$ECR_REPOSITORY:izgw-hub-${{env.VERSION}}_${{github.run_number}}
           docker image push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY


### PR DESCRIPTION
Update name of image pushed to APHL when release is cut, per request. Also only push one tag, per request. 

GitHub Organization Secrets have been updated

- APHL_ECR_REGISTRY = 273687833332.dkr.ecr.us-west-1.amazonaws.com/izgateway-ha
- APHL_ECR_REPOSITORY = ecr-repo
- APHL_AWS_ACCESS_KEY_ID = you can find value in AWS secrets
- APHL_AWS_SECRET_ACCESS_KEY = you can find value in AWS secrets