### PR TITLE
IGDD-2104 - CI/CD Updates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -232,6 +232,35 @@ jobs:
         name: DependencyCheck
         path: ./target/site/dependency-check-report.html
 
+    - name: Publish Site (Develop)
+      # Publish to /develop/ for: push to develop, PRs targeting develop, scheduled runs, manual dispatch
+      if: |
+        github.ref == 'refs/heads/develop' ||
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop')
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/site
+        destination_dir: develop
+
+    - name: Publish Site (Current)
+      # Publish to /current/ only on Release branch push
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/Release')
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/site
+        destination_dir: current
+
+    - name: Publish Site (Versioned)
+      # Publish to /v{version}/ only on Release branch push (same time as APHL push)
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/Release')
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/site
+        destination_dir: v${{ env.BASE_TAG }}
+
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,10 @@ on:
       - Release*
       - develop
 
+  # Schedule runs on the default branch.
+  schedule:
+    - cron: '0 6 * * 1-5'
+
 # Ensure only one build changes dev environment at the same time    
 concurrency: dev
 # GITHUB_REF=refs/heads/testmain
@@ -32,11 +36,11 @@ jobs:
       with:
         ssh-key: ${{secrets.ACTIONS_KEY}}
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
-        distribution: 'adopt'
+        java-version: '21'
+        distribution: 'temurin'
         cache: maven
 
     - name: Set up Maven
@@ -57,11 +61,11 @@ jobs:
             <toolchain>
               <type>jdk</type>
                 <provides>
-                  <version>11</version>
+                  <version>21</version>
                   <vendor>sun</vendor>
                 </provides>
                 <configuration>
-                  <jdkHome>$JAVA_HOME_11_X64</jdkHome>
+                  <jdkHome>$JAVA_HOME_21_X64</jdkHome>
                 </configuration>
             </toolchain>
             <toolchain>
@@ -193,7 +197,7 @@ jobs:
         ELASTIC_API_KEY: ${{ secrets.ELASTIC_API_KEY }}
         AMAZON_DYNAMODB_TABLE: izgateway-devalb 
       run: |
-        env && mvn -B clean package install -Dbuildno=${{github.run_number}} \
+        env && mvn -B clean package install site -Dbuildno=${{github.run_number}} \
             -DdoRevisionCheck=${{env.DO_REVISION_CHECK}} \
             -DskipDependencyCheck=true \
             -Dimage.tag=$IMAGE_TAG
@@ -208,9 +212,10 @@ jobs:
       continue-on-error: true
       timeout-minutes: 5
       with:
-        project: V2 to FHIR
+        project: IZ Gateway Hub
         path: target/${{env.IMAGE_TAG}}.jar
         format: 'HTML'
+        out: 'target/site'
         args: >
           --ossIndexUsername ${{ secrets.OSS_INDEX_USERNAME }}
           --ossIndexPassword ${{ secrets.OSS_INDEX_PASSWORD }}       
@@ -225,7 +230,7 @@ jobs:
       if: ${{ always() }}
       with:
         name: DependencyCheck
-        path: ./reports
+        path: ./target/site/dependency-check-report.html
 
     - name: Login to Amazon ECR
       id: login-ecr

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>gov.cdc.izgw</groupId>
             <artifactId>izgw-core</artifactId>
-            <version>2.5.0-izgw-core-SNAPSHOT</version>
+            <version>3.0.0-izgw-core-SNAPSHOT</version>
         </dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,20 @@
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<buildno>${timestamp}</buildno>
 		<build.mode>SNAPSHOT</build.mode>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<!-- use -Dbuild.mode=RELEASE to create a release build -->
 		<image.version>${project.version}</image.version>
 		<image.tag>${project.artifactId}-${project.version}-${buildno}</image.tag>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.java.package>${project.groupId}</project.java.package>
+		<!-- JaCoCo Configuration -->
+		<jacoco.version>0.8.13</jacoco.version>
+		<jacoco.jar>${user.home}/.m2/repository/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}.jar</jacoco.jar>
+		<surefire.argLine>
+			-Xmx2048m
+			--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+			--add-opens=java.base/java.net=ALL-UNNAMED
+		</surefire.argLine>
 	</properties>
     <dependencyManagement>
         <dependencies>
@@ -394,6 +402,31 @@
 						</dependency>
 					</dependencies>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.21.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>${jacoco.version}</version>
+					<executions>
+						<execution>
+							<id>prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>report</id>
+							<phase>verify</phase>
+							<goals>
+								<goal>report</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -429,8 +462,8 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>17</source>
-					<target>17</target>
+					<source>21</source>
+					<target>21</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>
@@ -569,6 +602,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 	<reporting>
@@ -581,6 +618,80 @@
 					<reportSet>
 						<reports>
 							<report>analyze-report</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.12.0</version>
+				<configuration>
+					<failOnError>false</failOnError>
+					<additionalJOption>-Xdoclint:none</additionalJOption>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-project-info-reports-plugin</artifactId>
+				<version>3.6.1</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>index</report>
+							<report>dependencies</report>
+							<report>dependency-info</report>
+							<report>dependency-management</report>
+							<report>distribution-management</report>
+							<report>licenses</report>
+							<report>scm</report>
+							<report>summary</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>3.5.3</version>
+			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>8.4.3</version>
+				<configuration>
+					<!--nvdApiKey>${env.NVDAPIKEY}</nvdApiKey-->
+					<formats>
+						<format>HTML</format>
+					</formats>
+					<!-- Disable .NET Analyzer -->
+					<assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+					<nugetconfAnalyzerEnabled>false</nugetconfAnalyzerEnabled>
+					<nuspecAnalyzerEnabled>false</nuspecAnalyzerEnabled>
+					<!-- Fail builds where this is used to 7 High to Critical -->
+					<failBuildOnCVSS>7</failBuildOnCVSS>
+					<!-- Don't fail on error (for cases where CVE REPO is bad) -->
+					<failOnError>false</failOnError>
+					<skip>${skipDependencyCheck}</skip>
+					<suppressionFile>${project.basedir}/dependency-suppression.xml</suppressionFile>
+					<outputDirectory>target/site</outputDirectory>
+				</configuration>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>check</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.13</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>report</report>
 						</reports>
 					</reportSet>
 				</reportSets>


### PR DESCRIPTION
**Java Version Upgrade**
- Upgraded from Java 17 to Java 21 both in pom.xml and GitHub Action

**GitHub Workflow Changes**
  - Added scheduled builds (cron: weekdays at 6 AM UTC)
  - Added site goal to the Maven build command
  - Renamed dependency-check project from "V2 to FHIR" to "IZG Transformation Service"
  - Changed dependency-check report output to target/site for publishing
  - Added three new GitHub Pages publishing steps:
    - Develop: publishes to /develop/ for develop branch pushes/PRs
    - Current: publishes to /current/ on Release branch pushes
    - Versioned: publishes to /v{version}/ on Release branch pushes

  **Maven Site & Reporting (pom.xml)**
  - Added JaCoCo code coverage plugin (version 0.8.13)
  - Added maven-site-plugin (version 3.21.0)
  - Added reporting plugins:
    - maven-javadoc-plugin - API documentation
    - maven-project-info-reports-plugin - project info reports (dependencies, licenses, SCM, etc.)
    - maven-surefire-report-plugin - test reports
    - dependency-check-maven - OWASP vulnerability scanning
    - jacoco-maven-plugin - code coverage reports
