### PR TITLE
Testing a potential performance improvement in hub

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,8 +57,9 @@ server:
     tomcat:
         accept-count: 200
         max-connections: 16384
-        max-threads: 400
-        max-keep-alive-requests: 1
+        max-threads: 800
+        # ALB configuration will run better with keep-alive requests disabled
+        max-keep-alive-requests: -1
         
     ssl:
         enabled: true


### PR DESCRIPTION
During performance testing, IZGW Hub only gets to about 35% CPU when running performance tests.  This leads me to believe that more requests can be processed if we increase the number of threads available.  By doubling the number of threads, we should be able to get to 70-75% CPU, at which point IZGW should begin to scale up in ECS.