### PR TITLE
IGDD-2585 - Update Postman WSDL tests to pull Content-Type differently

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,4 +1,4 @@
 <factorypath>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/projectlombok/lombok/1.18.42/lombok-1.18.42.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/projectlombok/lombok/1.18.44/lombok-1.18.44.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="PLUGIN" id="org.eclipse.jst.ws.annotations.core" enabled="false" runInBatchMode="false"/>
 </factorypath>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -347,14 +347,18 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: '--http-parser=legacy'
     steps:
 
     - name: Collect Workflow Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
 
     - uses: actions/checkout@v4
+
+    - name: Pin Node.js to 20.20.1
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.20.1'
+
     - name: Set up Tools
       shell: bash
       run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -452,7 +452,6 @@ jobs:
           "--env-var" "build=`grep Build target\classes\build.txt | cut '-d:' -f2 | cut -c2-99`" \
           "--env-var" "timestamp=`grep Timestamp target\classes\build.txt | cut '-d:' -f2 | cut -c2-99`" \
           "--environment" ../scripts/dev.postman_environment.json \
-          "--timeout-request" 360000 \
           "--ssl-extra-ca-certs" certs/izgwroot.pem \
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -433,7 +433,6 @@ jobs:
         # Just Running the Smoke Test ONCE should be enough to warm up
         newman run ../scripts/IZGW_2.0_Integration_Test.postman_collection.json -n 1 --folder "Smoke Test" \
           "--environment" ../scripts/dev.postman_environment.json \
-          "--timeout-request 360000" \
           "--ssl-extra-ca-certs" ../certs/izgwroot.pem \
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \
@@ -453,6 +452,7 @@ jobs:
           "--env-var" "build=`grep Build target\classes\build.txt | cut '-d:' -f2 | cut -c2-99`" \
           "--env-var" "timestamp=`grep Timestamp target\classes\build.txt | cut '-d:' -f2 | cut -c2-99`" \
           "--environment" ../scripts/dev.postman_environment.json \
+          "--timeout-request" 360000 \
           "--ssl-extra-ca-certs" certs/izgwroot.pem \
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -347,15 +347,12 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
-    env:
-      UV_TCP_KEEPALIVE_TIMEOUT: "120000"
     steps:
 
     - name: Collect Workflow Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
 
     - uses: actions/checkout@v4
-
     - name: Set up Tools
       shell: bash
       run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -347,6 +347,8 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--http-parser=legacy'
     steps:
 
     - name: Collect Workflow Telemetry

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -433,6 +433,7 @@ jobs:
         # Just Running the Smoke Test ONCE should be enough to warm up
         newman run ../scripts/IZGW_2.0_Integration_Test.postman_collection.json -n 1 --folder "Smoke Test" \
           "--environment" ../scripts/dev.postman_environment.json \
+          "--timeout-request 360000" \
           "--ssl-extra-ca-certs" ../certs/izgwroot.pem \
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -347,17 +347,14 @@ jobs:
   verify:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      UV_TCP_KEEPALIVE_TIMEOUT: "120000"
     steps:
 
     - name: Collect Workflow Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
 
     - uses: actions/checkout@v4
-
-    - name: Pin Node.js to 20.20.1
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.20.1'
 
     - name: Set up Tools
       shell: bash
@@ -462,6 +459,7 @@ jobs:
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \
           "--ssl-client-passphrase" $TESTING_PASS \
+          "--timeout-request" 120000 \
           "--insecure" --reporters cli,junitfull --reporter-junitfull-export ../logs/integration-test.xml
 
         xunit-viewer -r ../logs/integration-test.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -456,7 +456,6 @@ jobs:
           "--ssl-client-cert" ../newman.pem \
           "--ssl-client-key" ../newman.key \
           "--ssl-client-passphrase" $TESTING_PASS \
-          "--timeout-request" 120000 \
           "--insecure" --reporters cli,junitfull --reporter-junitfull-export ../logs/integration-test.xml
 
         xunit-viewer -r ../logs/integration-test.xml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath />
 	</parent>
 	<artifactId>izgw-hub</artifactId>

--- a/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
+++ b/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
@@ -1,10 +1,10 @@
 {
   "info": {
-    "_postman_id": "9d291434-2eb7-44db-ac8a-cebddedc5f58",
+    "_postman_id": "7ccc8390-7ad9-4008-bbdd-83d73a0439ad",
     "name": "IZGW 2.0 Integtration Test",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "940288",
-    "_collection_link": "https://go.postman.co/collection/940288-9d291434-2eb7-44db-ac8a-cebddedc5f58?source=collection_link"
+    "_exporter_id": "2729094",
+    "_collection_link": "https://go.postman.co/collection/2729094-7ccc8390-7ad9-4008-bbdd-83d73a0439ad?source=collection_link"
   },
   "item": [
     {
@@ -390,13 +390,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -404,7 +398,9 @@
                       "    pm.expect(responseBody).to.match(/\\/(<[a-zA-Z0-9_]+:)?definitions/);\r",
                       "});"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -413,7 +409,9 @@
                     "exec": [
                       "utils.setup(pm);"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -470,13 +468,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -484,7 +476,9 @@
                       "    pm.expect(responseBody).to.match(/\\/(<[a-zA-Z0-9_]+:)?definitions/);\r",
                       "});"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -493,7 +487,9 @@
                     "exec": [
                       "utils.setup(pm);"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -550,13 +546,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -565,7 +555,8 @@
                       "});"
                     ],
                     "type": "text/javascript",
-                    "packages": {}
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -575,7 +566,8 @@
                       "utils.setup(pm);"
                     ],
                     "type": "text/javascript",
-                    "packages": {}
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -13773,7 +13765,10 @@
           "name": "New Request",
           "request": {
             "method": "GET",
-            "header": []
+            "header": [],
+            "url": {
+              "raw": ""
+            }
           },
           "response": []
         }

--- a/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
+++ b/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
@@ -6005,127 +6005,6 @@
               "response": []
             },
             {
-              "name": "TC_13c Test against Unresponsive or down  IIS",
-              "event": [
-                {
-                  "listen": "test",
-                  "script": {
-                    "exec": [
-                      "const testDisabled = true\r",
-                      "if (!testDisabled) {\r",
-                      "pm.test(\"Status code is 500\", function () {\r",
-                      "    pm.response.to.have.status(500);\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Response has DestinationConnectionFault\", function () {\r",
-                      "    pm.expect(responseBody).to.contain('DestinationConnectionFault>');\r",
-                      "    pm.expect(responseBody).to.contain('urn:cdc:iisb:hub:2014:IISHubPortType:SubmitSingleMessage:Fault:DestinationConnectionFault');\r",
-                      "});\r",
-                      "\r",
-                      "pm.test(\"Response has correct soap reason about connection time out\", function () {\r",
-                      "    var jsonObject = xml2Json(responseBody);\r",
-                      "    var reasonText= jsonObject['soap:Envelope']['soap:Body']['soap:Fault']['soap:Reason']['soap:Text']['_'];\r",
-                      "    pm.expect(reasonText).to.include(\"Connect Timeout\");\r",
-                      "});\r",
-                      "\r",
-                      "var response = utils.removeNS(xml2Json(responseBody));\r",
-                      "pm.test(\"Response has Summary = ConnectTimeout\", function() {\r",
-                      "   var summary = response['Envelope']['Body']['Fault']['Detail']['Summary'];\r",
-                      "   pm.expect(summary).to.be.eql('ConnectTimeout');\r",
-                      "});\r",
-                      "pm.test(\"Response has Retry = CHECK_IIS_STATUS\", function() {\r",
-                      "   var retry = response['Envelope']['Body']['Fault']['Detail']['Retry'];\r",
-                      "   pm.expect(retry).to.be.eql('CHECK_IIS_STATUS');\r",
-                      "});\r",
-                      "\r",
-                      "const interval = setTimeout(() => {}, 3000);\r",
-                      "async function moreTests() {\r",
-                      "    utils.getLogs(null, pm).then((logData) => {\r",
-                      "        logs = logData.json();\r",
-                      "        utils.testLogs(logs, pm, 0, \"DestinationConnectionFault\", \"ConnectTimeout\", \"CHECK_IIS_STATUS\");\r",
-                      "\r",
-                      "        txData = utils.getTxData(logs);\r",
-                      "        for (entry of txData) {\r",
-                      "            // Only check entries for Gateway, not for Mock\r",
-                      "            if (entry.transactionData.serviceType != \"Gateway\") {\r",
-                      "                continue;\r",
-                      "            }\r",
-                      "            if (entry.eventId < 2) continue; // Skip internal calls\r",
-                      "            pm.test(\"transactionData.destination.id is not null\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.id).to.not.be.eql(null);\r",
-                      "            });\r",
-                      "            pm.test(\"transactionData.destination.url is not null\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.url).to.not.be.eql(null);\r",
-                      "            });\r",
-                      "            pm.test(\"transactionData.destination.connected is false\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.connected).to.be.eql(false);\r",
-                      "            });\r",
-                      "            pm.test(\"transactionData.destination.ipAddress is not 'unknown'\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.ipAddress).to.not.be.eql(\"unknown\");\r",
-                      "            });\r",
-                      "            pm.test(\"transactionData.destination.cipherSuite is null\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.cipherSuite).to.be.eql(null);\r",
-                      "            });\r",
-                      "            pm.test(\"transactionData.destination.commonName is null\", function () {\r",
-                      "                pm.expect(entry.transactionData.destination.cipherSuite).to.be.eql(null);\r",
-                      "            });\r",
-                      "        }           \r",
-                      "    });\r",
-                      "}\r",
-                      " if(!pm.environment.get(\"host\").endsWith(\"phiz-project.org\")) moreTests();\r",
-                      "}\r"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                },
-                {
-                  "listen": "prerequest",
-                  "script": {
-                    "exec": [
-                      "utils.setup(pm, \"down\");"
-                    ],
-                    "type": "text/javascript",
-                    "packages": {}
-                  }
-                }
-              ],
-              "protocolProfileBehavior": {
-                "disabledSystemHeaders": {
-                  "host": true
-                }
-              },
-              "request": {
-                "method": "POST",
-                "header": [
-                  {
-                    "key": "Host",
-                    "value": "{{hostHeader}}"
-                  },
-                  {
-                    "key": "Content-Type",
-                    "value": "application/xml"
-                  }
-                ],
-                "body": {
-                  "mode": "raw",
-                  "raw": "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:urn=\"urn:cdc:iisb:hub:2014\" xmlns:urn1=\"urn:cdc:iisb:2014\">\r\n  <soap:Header xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\r\n    <urn:HubRequestHeader>\r\n      <urn:DestinationId>down</urn:DestinationId>\r\n    </urn:HubRequestHeader>\r\n    <wsa:Action>urn:cdc:iisb:hub:2014:IISHubPortType:SubmitSingleMessageRequest</wsa:Action>\r\n    <wsa:MessageID>{{testMessageId}}</wsa:MessageID>\r\n  </soap:Header>\r\n  <soap:Body>\r\n    <urn1:SubmitSingleMessageRequest>\r\n      <urn1:FacilityID>IZG</urn1:FacilityID>\r\n      <urn1:Hl7Message>MSH|^~\\&amp;|||TEST|TC_13C|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374</urn1:Hl7Message>\r\n    </urn1:SubmitSingleMessageRequest>\r\n  </soap:Body>\r\n</soap:Envelope>"
-                },
-                "url": {
-                  "raw": "https://{{host}}:{{port}}/IISHubService",
-                  "protocol": "https",
-                  "host": [
-                    "{{host}}"
-                  ],
-                  "port": "{{port}}",
-                  "path": [
-                    "IISHubService"
-                  ]
-                }
-              },
-              "response": []
-            },
-            {
               "name": "TC_13d Test against Rejecting IIS",
               "event": [
                 {
@@ -9670,7 +9549,8 @@
                           "utils.setup(pm);"
                         ],
                         "type": "text/javascript",
-                        "packages": {}
+                        "packages": {},
+                        "requests": {}
                       }
                     },
                     {
@@ -9713,7 +9593,8 @@
                           ""
                         ],
                         "type": "text/javascript",
-                        "packages": {}
+                        "packages": {},
+                        "requests": {}
                       }
                     }
                   ],
@@ -13104,6 +12985,124 @@
           ]
         },
         {
+          "name": "TC_13c Test against Unresponsive or down  IIS",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 500\", function () {\r",
+                  "    pm.response.to.have.status(500);\r",
+                  "});\r",
+                  "\r",
+                  "pm.test(\"Response has DestinationConnectionFault\", function () {\r",
+                  "    pm.expect(responseBody).to.contain('DestinationConnectionFault>');\r",
+                  "    pm.expect(responseBody).to.contain('urn:cdc:iisb:hub:2014:IISHubPortType:SubmitSingleMessage:Fault:DestinationConnectionFault');\r",
+                  "});\r",
+                  "\r",
+                  "pm.test(\"Response has correct soap reason about connection time out\", function () {\r",
+                  "    var jsonObject = xml2Json(responseBody);\r",
+                  "    var reasonText= jsonObject['soap:Envelope']['soap:Body']['soap:Fault']['soap:Reason']['soap:Text']['_'];\r",
+                  "    pm.expect(reasonText).to.include(\"Connect Timeout\");\r",
+                  "});\r",
+                  "\r",
+                  "var response = utils.removeNS(xml2Json(responseBody));\r",
+                  "pm.test(\"Response has Summary = ConnectTimeout\", function() {\r",
+                  "   var summary = response['Envelope']['Body']['Fault']['Detail']['Summary'];\r",
+                  "   pm.expect(summary).to.be.eql('ConnectTimeout');\r",
+                  "});\r",
+                  "pm.test(\"Response has Retry = CHECK_IIS_STATUS\", function() {\r",
+                  "   var retry = response['Envelope']['Body']['Fault']['Detail']['Retry'];\r",
+                  "   pm.expect(retry).to.be.eql('CHECK_IIS_STATUS');\r",
+                  "});\r",
+                  "\r",
+                  "const interval = setTimeout(() => {}, 3000);\r",
+                  "async function moreTests() {\r",
+                  "    utils.getLogs(null, pm).then((logData) => {\r",
+                  "        logs = logData.json();\r",
+                  "        utils.testLogs(logs, pm, 0, \"DestinationConnectionFault\", \"ConnectTimeout\", \"CHECK_IIS_STATUS\");\r",
+                  "\r",
+                  "        txData = utils.getTxData(logs);\r",
+                  "        for (entry of txData) {\r",
+                  "            // Only check entries for Gateway, not for Mock\r",
+                  "            if (entry.transactionData.serviceType != \"Gateway\") {\r",
+                  "                continue;\r",
+                  "            }\r",
+                  "            if (entry.eventId < 2) continue; // Skip internal calls\r",
+                  "            pm.test(\"transactionData.destination.id is not null\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.id).to.not.be.eql(null);\r",
+                  "            });\r",
+                  "            pm.test(\"transactionData.destination.url is not null\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.url).to.not.be.eql(null);\r",
+                  "            });\r",
+                  "            pm.test(\"transactionData.destination.connected is false\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.connected).to.be.eql(false);\r",
+                  "            });\r",
+                  "            pm.test(\"transactionData.destination.ipAddress is not 'unknown'\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.ipAddress).to.not.be.eql(\"unknown\");\r",
+                  "            });\r",
+                  "            pm.test(\"transactionData.destination.cipherSuite is null\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.cipherSuite).to.be.eql(null);\r",
+                  "            });\r",
+                  "            pm.test(\"transactionData.destination.commonName is null\", function () {\r",
+                  "                pm.expect(entry.transactionData.destination.cipherSuite).to.be.eql(null);\r",
+                  "            });\r",
+                  "        }           \r",
+                  "    });\r",
+                  "}\r",
+                  " if(!pm.environment.get(\"host\").endsWith(\"phiz-project.org\")) moreTests();"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            },
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "utils.setup(pm, \"down\");"
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "protocolProfileBehavior": {
+            "disabledSystemHeaders": {
+              "host": true
+            }
+          },
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Host",
+                "value": "{{hostHeader}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/xml"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:urn=\"urn:cdc:iisb:hub:2014\" xmlns:urn1=\"urn:cdc:iisb:2014\">\r\n  <soap:Header xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">\r\n    <urn:HubRequestHeader>\r\n      <urn:DestinationId>down</urn:DestinationId>\r\n    </urn:HubRequestHeader>\r\n    <wsa:Action>urn:cdc:iisb:hub:2014:IISHubPortType:SubmitSingleMessageRequest</wsa:Action>\r\n    <wsa:MessageID>{{testMessageId}}</wsa:MessageID>\r\n  </soap:Header>\r\n  <soap:Body>\r\n    <urn1:SubmitSingleMessageRequest>\r\n      <urn1:FacilityID>IZG</urn1:FacilityID>\r\n      <urn1:Hl7Message>MSH|^~\\&amp;|||TEST|TC_13C|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374</urn1:Hl7Message>\r\n    </urn1:SubmitSingleMessageRequest>\r\n  </soap:Body>\r\n</soap:Envelope>"
+            },
+            "url": {
+              "raw": "https://{{host}}:{{port}}/IISHubService",
+              "protocol": "https",
+              "host": [
+                "{{host}}"
+              ],
+              "port": "{{port}}",
+              "path": [
+                "IISHubService"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Blacklist a User",
           "request": {
             "method": "POST",
@@ -14961,8 +14960,7 @@
   "variable": [
     {
       "key": "GoodMessage",
-      "value": "MSH|^~\\&amp;|IRIS IIS|IRIS|TEST|TC_04|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374|\nQPD|Z34^Request Immunization History^CDCPHINVS|20210330093013LA231|LAMASM77BF4BA6^^^IZGATEWAYTEST&amp;2.16.840.1.113883.40.1&amp;ISO^MR|JohnsonIZG^James^Andrew^^^^L|Leung^Jen^^^^^M|20160414|M|Main Street&amp;&amp;123^^New Orleans^LA^70115^^L|^PRN^PH^^^555^5551111|Y|1",
-      "type": "string"
+      "value": "MSH|^~\\&amp;|IRIS IIS|IRIS|TEST|TC_04|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374|\nQPD|Z34^Request Immunization History^CDCPHINVS|20210330093013LA231|LAMASM77BF4BA6^^^IZGATEWAYTEST&amp;2.16.840.1.113883.40.1&amp;ISO^MR|JohnsonIZG^James^Andrew^^^^L|Leung^Jen^^^^^M|20160414|M|Main Street&amp;&amp;123^^New Orleans^LA^70115^^L|^PRN^PH^^^555^5551111|Y|1"
     },
     {
       "key": "GoodResponse",
@@ -15006,13 +15004,11 @@
     },
     {
       "key": "azure-endpoint",
-      "value": "azurite",
-      "type": "string"
+      "value": "azurite"
     },
     {
       "key": "dex-endpoint",
-      "value": "dex-dev",
-      "type": "string"
+      "value": "dex-dev"
     }
   ]
 }

--- a/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
+++ b/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
@@ -6011,6 +6011,8 @@
                   "listen": "test",
                   "script": {
                     "exec": [
+                      "const testDisabled = true\r",
+                      "if (!testDisabled) {\r",
                       "pm.test(\"Status code is 500\", function () {\r",
                       "    pm.response.to.have.status(500);\r",
                       "});\r",
@@ -6070,7 +6072,8 @@
                       "        }           \r",
                       "    });\r",
                       "}\r",
-                      " if(!pm.environment.get(\"host\").endsWith(\"phiz-project.org\")) moreTests();"
+                      " if(!pm.environment.get(\"host\").endsWith(\"phiz-project.org\")) moreTests();\r",
+                      "}\r"
                     ],
                     "type": "text/javascript",
                     "packages": {}

--- a/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
+++ b/testing/scripts/IZGW_2.0_Integration_Test.postman_collection.json
@@ -1,10 +1,10 @@
 {
   "info": {
-    "_postman_id": "9d291434-2eb7-44db-ac8a-cebddedc5f58",
+    "_postman_id": "7ccc8390-7ad9-4008-bbdd-83d73a0439ad",
     "name": "IZGW 2.0 Integtration Test",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "940288",
-    "_collection_link": "https://go.postman.co/collection/940288-9d291434-2eb7-44db-ac8a-cebddedc5f58?source=collection_link"
+    "_exporter_id": "2729094",
+    "_collection_link": "https://go.postman.co/collection/2729094-7ccc8390-7ad9-4008-bbdd-83d73a0439ad?source=collection_link"
   },
   "item": [
     {
@@ -390,13 +390,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -404,7 +398,9 @@
                       "    pm.expect(responseBody).to.match(/\\/(<[a-zA-Z0-9_]+:)?definitions/);\r",
                       "});"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -413,7 +409,9 @@
                     "exec": [
                       "utils.setup(pm);"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -470,13 +468,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -484,7 +476,9 @@
                       "    pm.expect(responseBody).to.match(/\\/(<[a-zA-Z0-9_]+:)?definitions/);\r",
                       "});"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -493,7 +487,9 @@
                     "exec": [
                       "utils.setup(pm);"
                     ],
-                    "type": "text/javascript"
+                    "type": "text/javascript",
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -550,13 +546,7 @@
                       "});\r",
                       "\r",
                       "pm.test(\"Content-Type is correct\", function () {\r",
-                      "    var contentType = null;\r",
-                      "    for (header in pm.response.headers.members) {\r",
-                      "        if (pm.response.headers.members[header].key == \"Content-Type\") {\r",
-                      "            contentType = pm.response.headers.members[header].value;\r",
-                      "            break;\r",
-                      "        }\r",
-                      "    }\r",
+                      "    var contentType = pm.response.headers.get(\"Content-Type\");\r",
                       "    pm.expect(contentType).to.match(/[\\/+]xml/);\r",
                       "});\r",
                       "\r",
@@ -565,7 +555,8 @@
                       "});"
                     ],
                     "type": "text/javascript",
-                    "packages": {}
+                    "packages": {},
+                    "requests": {}
                   }
                 },
                 {
@@ -575,7 +566,8 @@
                       "utils.setup(pm);"
                     ],
                     "type": "text/javascript",
-                    "packages": {}
+                    "packages": {},
+                    "requests": {}
                   }
                 }
               ],
@@ -13771,7 +13763,10 @@
           "name": "New Request",
           "request": {
             "method": "GET",
-            "header": []
+            "header": [],
+            "url": {
+              "raw": ""
+            }
           },
           "response": []
         }
@@ -14958,8 +14953,7 @@
   "variable": [
     {
       "key": "GoodMessage",
-      "value": "MSH|^~\\&amp;|IRIS IIS|IRIS|TEST|TC_04|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374|\nQPD|Z34^Request Immunization History^CDCPHINVS|20210330093013LA231|LAMASM77BF4BA6^^^IZGATEWAYTEST&amp;2.16.840.1.113883.40.1&amp;ISO^MR|JohnsonIZG^James^Andrew^^^^L|Leung^Jen^^^^^M|20160414|M|Main Street&amp;&amp;123^^New Orleans^LA^70115^^L|^PRN^PH^^^555^5551111|Y|1",
-      "type": "string"
+      "value": "MSH|^~\\&amp;|IRIS IIS|IRIS|TEST|TC_04|20210402091512.000-0100||QBP^Q11^QBP_Q11|20210330093013AZQ231|P|2.5.1|||ER|AL|||||Z34^CDCPHINVS|SIISCLIENT28374|\nQPD|Z34^Request Immunization History^CDCPHINVS|20210330093013LA231|LAMASM77BF4BA6^^^IZGATEWAYTEST&amp;2.16.840.1.113883.40.1&amp;ISO^MR|JohnsonIZG^James^Andrew^^^^L|Leung^Jen^^^^^M|20160414|M|Main Street&amp;&amp;123^^New Orleans^LA^70115^^L|^PRN^PH^^^555^5551111|Y|1"
     },
     {
       "key": "GoodResponse",
@@ -15003,13 +14997,11 @@
     },
     {
       "key": "azure-endpoint",
-      "value": "azurite",
-      "type": "string"
+      "value": "azurite"
     },
     {
       "key": "dex-endpoint",
-      "value": "dex-dev",
-      "type": "string"
+      "value": "dex-dev"
     }
   ]
 }

--- a/testing/scripts/dev.postman_environment.json
+++ b/testing/scripts/dev.postman_environment.json
@@ -4,7 +4,7 @@
 	"values": [
 		{
 			"key": "host",
-			"value": "izgateway-devalb-alb-1199787319.us-east-1.elb.amazonaws.com",
+			"value": "dev.izgateway.org",
 			"enabled": true
 		},
 		{

--- a/testing/scripts/dev.postman_environment.json
+++ b/testing/scripts/dev.postman_environment.json
@@ -4,7 +4,7 @@
 	"values": [
 		{
 			"key": "host",
-			"value": "dev.izgateway.org",
+			"value": "izgateway-devalb-alb-1199787319.us-east-1.elb.amazonaws.com",
 			"enabled": true
 		},
 		{


### PR DESCRIPTION
3 tests were obtaining the Content-Type via something like this:

```
    var contentType = null;
    for (header in pm.response.headers.members) {
        if (pm.response.headers.members[header].key == "Content-Type") {
            contentType = pm.response.headers.members[header].value;
            break;
        }
    }
```

Issue is that a recent Postman update lets you set the HTTP version for requests:

<img width="609" height="95" alt="image" src="https://github.com/user-attachments/assets/31b6a4e9-3809-40b2-8e64-49908c3dc937" />

It was defaulting to Auto and using HTTP 2.x where the key was content-type and if HTTP 1.x was Content-Type. This caused test failures for 3 tests because the contentType var was being set to null

Updated these 3 tests to use `pm.response.headers.get("Content-Type")` which does a case in-sensitive lookup.

The 3 affected tests:

- TC_03a Retrieval of WSDL
- TC_03b Retrieval of IIS Service WSDL
- TC_03c Retrieval of Schema