### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     # This step should only be done on PUSH to main
     if: github.ref == 'refs/heads/testmain' || github.ref == 'refs/heads/main'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       # Necessary to enable push to protected branch
       with:
         ssh-key: ${{secrets.ACTIONS_KEY}}
@@ -130,7 +130,7 @@ jobs:
 
     - name: Create GitHub Release
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -143,7 +143,7 @@ jobs:
           ./docs/release/*.md
 
     - name: Upload release documentation as artifact for failed release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: release-failure

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,20 +35,20 @@ jobs:
     steps:
 
     - name: Checkout the software
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # Necessary to enable push to protected branch
       with:
         ssh-key: ${{secrets.ACTIONS_KEY}}
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@v5
+      uses: stCarolas/setup-maven@v5.1
       with:
         maven-version: 3.9.0
 
@@ -202,7 +202,7 @@ jobs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Cache Dependency-Check NVD data
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/dependency-check-data
         key: dependency-check-nvd-${{ runner.os }}-${{ steps.date.outputs.date }}
@@ -235,7 +235,7 @@ jobs:
           --disableCentral
 
     - name: Upload dependency check log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: DependencyCheck
@@ -246,7 +246,7 @@ jobs:
       if: |
         github.ref == 'refs/heads/develop' ||
         (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop')
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/site
@@ -255,7 +255,7 @@ jobs:
     - name: Publish Site (Current)
       # Publish to /current/ only on Release branch push
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/Release')
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/site
@@ -264,7 +264,7 @@ jobs:
     - name: Publish Site (Versioned)
       # Publish to /v{version}/ only on Release branch push (same time as APHL push)
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/Release')
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/site
@@ -275,14 +275,14 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v2
       
     - name: Login to GitHub Repository
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
           
     - name: Build and push Docker Image
       env:
@@ -335,14 +335,14 @@ jobs:
         wait
 
     - name: Upload build environment as artifact for failed build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: build-failure
         path: .
 
     - name: Upload dependency check log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: DependencyCheck
@@ -364,7 +364,7 @@ jobs:
     - name: Collect Workflow Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Enable TCP keepalive for long-running requests
       run: |
@@ -378,7 +378,7 @@ jobs:
         echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
 
     - name: Cache npm globals
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.npm-global
         key: npm-globals-${{ hashFiles('.github/workflows/maven.yml') }}
@@ -505,14 +505,14 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:good
 
     - name: Upload test logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: TestLogs
         path: ./testing/logs
 
     - name: Upload build environment as artifact for failed build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: verify-failure

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -361,9 +361,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Collect Workflow Telemetry
-      uses: catchpoint/workflow-telemetry-action@v2
-
     - uses: actions/checkout@v6
 
     - name: Enable TCP keepalive for long-running requests


### PR DESCRIPTION
- Updated all workflow actions to their latest stable Node.js 24 compatible versions (node20 deprecated, forced to node24 June 2 2026)
- Added .github/dependabot.yml to keep action versions up-to-date automatically going forward (weekly, major versions only)