### PR TITLE
ci: pin Docker actions to commit SHAs for supply-chain security

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -275,14 +275,14 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v2
       
     - name: Login to GitHub Repository
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
           
     - name: Build and push Docker Image
       env:


### PR DESCRIPTION
## Summary

Pins Docker GitHub Actions to immutable commit SHAs instead of movable version tags.

**Why:** A movable tag (e.g. `@v7`) can be silently updated by a compromised upstream account to point to malicious code. A commit SHA pin is immutable — your workflow always runs the exact bytes you reviewed.

## Changes

| Action | Before | After |
|---|---|---|
| `docker/build-push-action` | `@v7` | `@f9f3042f7e27…` (v7) |
| `docker/login-action` | `@v4` | `@650006c6eb7d…` (v4) |
| `docker/metadata-action` | `@v6` | `@80c7e94dd9b9…` (v6) |
| `docker/setup-buildx-action` | `@v4` | `@d7f5e7f509e4…` (v4) |

## Keeping SHAs up to date

Dependabot is already configured on these repos (added in IGDD-2803). It will automatically open PRs when these SHAs need to advance to a newer release — no manual tracking needed.

## Test plan

- [ ] Verify workflows still trigger and pass on this branch
- [ ] Confirm Docker build/push steps complete successfully