### PR TITLE
IGDD-2705 - Adding OpenSpec and code changes to remove roles from the JWT.

### DIFF
--- a/openspec/changes/jwt-upn-authorization/.openspec.yaml
+++ b/openspec/changes/jwt-upn-authorization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/jwt-upn-authorization/design.md
+++ b/openspec/changes/jwt-upn-authorization/design.md
@@ -1,0 +1,67 @@
+## Context
+
+`igdd-2705-api-key-principal-provider` introduced `ApiKeyPrincipal` with a `roles` field populated from the JWT `roles` claim, and added a corresponding fallback in `AccessControlService.isUserInRole()` that reads those roles when the DynamoDB AccessGroup lookup finds no match. This created two authorization paths:
+
+- **mTLS cert clients**: identity = cert CN → DynamoDB AccessGroup lookup (only path)
+- **JWT clients**: identity = UPN → DynamoDB AccessGroup lookup, then fall back to JWT-claim roles
+
+The requirement has changed: both auth types must use the same single authorization path. UPN is already set as `ApiKeyPrincipal.name`, so JWT principals already flow through the DynamoDB AccessGroup lookup — the fallback is the only thing bypassing it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the JWT-claim roles fallback from `AccessControlService.isUserInRole()`
+- Simplify `ApiKeyPrincipal` constructor to no longer accept or store JWT-sourced roles
+- Ensure the resulting authorization model is identical for cert and JWT clients
+
+**Non-Goals:**
+- Any change to the DynamoDB AccessGroup table schema or repository
+- Any change to JWT validation logic (signature, claims, credential cache)
+- Any change to Config Console JWT issuance — the `roles` claim in issued tokens is silently ignored; CC does not need to be updated
+- Adding JWT-specific authorization features (scopes, per-token role overrides, etc.)
+
+## Decisions
+
+### D1 — Remove the `ApiKeyPrincipal` instanceof fallback entirely
+
+`AccessControlService.isUserInRole()` currently has:
+```java
+var principal = RequestContext.getPrincipal();
+if (principal instanceof ApiKeyPrincipal apiKeyPrincipal) {
+    return apiKeyPrincipal.getRoles().contains(role);
+}
+```
+
+This block is removed. No replacement is needed — the `currentModelHelper.isUserInRole(user, role)` call that precedes it already performs the DynamoDB AccessGroup lookup using `user = principal.getName() = upn` for JWT clients.
+
+**Alternative considered**: Replace the fallback with a DynamoDB-aware check that explicitly notes it's the UPN path. Rejected — the existing `currentModelHelper.isUserInRole()` call already does this. Duplicating it would add noise without value.
+
+### D2 — Remove `roles` from `ApiKeyPrincipal` constructor, leave `IzgPrincipal.roles` field intact
+
+The `Collection<String> jwtRoles` constructor parameter is removed from `ApiKeyPrincipal`. The inherited `IzgPrincipal.roles` field (a `TreeSet`) remains — it is part of the core model used by `RequestContext.setPrincipal()` and is not specific to JWT clients. For `ApiKeyPrincipal` instances it will always be an empty set, which is the same as `CertificatePrincipal`.
+
+`RequestContext.setPrincipal()` calls `roles.set(izgPrincipal.getRoles())` — for both cert and JWT principals this will now be an empty set at principal-creation time. The `ADMIN` role is added to `RequestContext.getRoles()` by `AccessControlValve.updateRoles()` after a successful DynamoDB check, which is unchanged.
+
+**Alternative considered**: Remove `roles` from `IzgPrincipal` entirely. Rejected — out of scope; `izgw-core` changes require coordination with `izgw-transform` consumers.
+
+### D3 — Remove `roles` claim extraction from `ApiKeyPrincipalProvider`
+
+`lookupAndCacheCredential()` currently extracts `claims.getStringListClaim("roles")` and passes it to the `ApiKeyPrincipal` constructor. Both lines are removed. The `roles` claim in the JWT payload is neither validated nor stored from this point forward — it is present in the token but ignored by Hub.
+
+No JWT validation failure is introduced: the `roles` claim was never a required claim, and the `claims.getStringListClaim()` call was not used for any security decision.
+
+## Risks / Trade-offs
+
+- **JWT clients lose access until UPNs are provisioned in DynamoDB AccessGroups** → Mitigate by provisioning AccessGroup entries for all known JWT client UPNs before deploying this change. Verify in a non-production environment first.
+- **Silent behavior change for existing JWT tokens with `roles` claim** → The `roles` claim is ignored after this change. Any JWT client that relied on role escalation via the token (bypassing AccessGroups) will lose access. This is intentional — the change enforces operator-controlled authorization.
+- **`roles` claim in token is now dead weight** → Config Console may continue issuing it without harm, but new tooling should omit it. No urgent action required.
+
+## Migration Plan
+
+1. **Pre-deployment**: Verify that all active JWT client UPNs are present in the appropriate DynamoDB AccessGroups in each target environment.
+2. **Deploy**: No configuration changes required. The change is self-contained to Hub code.
+3. **Rollback**: Revert the three code changes and redeploy. No DynamoDB schema changes means rollback is clean.
+
+## Open Questions
+
+None.

--- a/openspec/changes/jwt-upn-authorization/proposal.md
+++ b/openspec/changes/jwt-upn-authorization/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+JWT client authorization currently uses roles embedded in the JWT claim, creating a separate authorization path from mTLS cert clients who are authorized via DynamoDB AccessGroup lookup. The requirement has changed: JWT clients must be authorized the same way as mTLS cert clients — using the UPN (which maps to the same DNS identity as the cert CN) as the lookup key in the DynamoDB AccessGroup table.
+
+## What Changes
+
+- **Removed**: `ApiKeyPrincipal` instanceof fallback in `AccessControlService.isUserInRole()` — JWT principals now use the same DynamoDB AccessGroup path as cert principals
+- **Removed**: `Collection<String> jwtRoles` constructor parameter from `ApiKeyPrincipal` — the principal no longer carries JWT-sourced roles
+- **Removed**: `roles` claim extraction from `ApiKeyPrincipalProvider.lookupAndCacheCredential()` — the `roles` claim is no longer read from the JWT
+- **Operational**: JWT client UPNs must be present in the DynamoDB AccessGroup table for authorization to succeed (same requirement as mTLS cert CNs)
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-key-principal-provider`: Authorization model changes — `ApiKeyPrincipal` no longer carries JWT-claim roles; `AccessControlService.isUserInRole()` no longer has a special fallback for JWT principals; UPN-based DynamoDB AccessGroup lookup is the sole authorization path for JWT clients.
+
+## Impact
+
+- **`AccessControlService`** — `isUserInRole()` loses the `ApiKeyPrincipal` fallback branch; JWT and cert principals now follow an identical code path
+- **`ApiKeyPrincipal`** — constructor simplified; `roles` field will always be empty (inherited from `IzgPrincipal` default)
+- **`ApiKeyPrincipalProvider`** — `lookupAndCacheCredential()` no longer extracts or passes `roles` from JWT claims
+- **Config Console** — `roles` claim in issued JWTs is now ignored by Hub; CC may continue emitting it without harm but no longer needs to
+- **DynamoDB AccessGroup table** — becomes the single source of truth for both auth types; JWT client UPNs must be provisioned into AccessGroups
+- **Tests** — any test asserting JWT-claim-sourced role resolution must be updated to use DynamoDB AccessGroup lookup instead

--- a/openspec/changes/jwt-upn-authorization/specs/api-key-principal-provider/spec.md
+++ b/openspec/changes/jwt-upn-authorization/specs/api-key-principal-provider/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: DynamoDB credential status check
+When the credential cache misses, Hub SHALL read the `ApiKeyCredential` record and act on its `status`:
+- **active** or **grace_period**: construct an `ApiKeyPrincipal` from JWT claims (`upn` → `name` (IzgPrincipal.getName()), `sub` → `organization` (a numeric string jurisdiction ID, e.g., `"42"`), `jti` → jti), store in credential cache with `jwt.credential-cache-ttl` (default 5 minutes), and return the principal. The `roles` field on the returned principal SHALL be empty; JWT claims SHALL NOT be used to populate roles.
+- **revoked**, **expired**, or record absent: store a REVOKED sentinel in credential cache with TTL equal to the maximum possible token lifetime (1 year), and return `null`.
+
+#### Scenario: Active credential
+- **WHEN** DynamoDB returns `status = active` for the `jti`
+- **THEN** an `ApiKeyPrincipal` is constructed with `name = upn`, empty `roles`, and cached with 5-minute TTL, then returned
+
+#### Scenario: Revoked credential
+- **WHEN** DynamoDB returns `status = revoked` for the `jti`
+- **THEN** a REVOKED sentinel is cached with max-token-lifetime TTL and `null` is returned, resulting in 401
+
+#### Scenario: Absent credential record
+- **WHEN** DynamoDB has no `ApiKeyCredential` record for `env#jti`
+- **THEN** the `jti` is cached in the absent cache (5-minute TTL) and `null` is returned
+
+## ADDED Requirements
+
+### Requirement: JWT client authorization via DynamoDB AccessGroup lookup
+Hub SHALL authorize JWT clients using the `upn` value as the identity key in DynamoDB AccessGroup lookups, identical to how mTLS cert clients are authorized using the certificate CN. `AccessControlService.isUserInRole()` SHALL NOT contain a special fallback for `ApiKeyPrincipal` instances that reads roles from the JWT token. The DynamoDB AccessGroup table is the sole source of role assignments for both JWT and cert principals.
+
+#### Scenario: JWT client UPN present in AccessGroup
+- **WHEN** a JWT client presents a valid token with `upn = immunize.example.gov` AND that UPN is a member of an AccessGroup with role `soap`
+- **THEN** the JWT client is authorized to call SOAP endpoints, identical to a cert client with CN `immunize.example.gov` in the same group
+
+#### Scenario: JWT client UPN absent from all AccessGroups
+- **WHEN** a JWT client presents a valid token with a `upn` that is not in any AccessGroup
+- **THEN** access is denied with 401, identical to a cert client whose CN is not in any group
+
+#### Scenario: JWT client UPN in admin AccessGroup
+- **WHEN** a JWT client presents a valid token with a `upn` that is in an AccessGroup with role `admin`
+- **THEN** `AccessControlValve.updateRoles()` adds `ADMIN` to `RequestContext.getRoles()`, granting admin privileges identical to an mTLS admin cert client

--- a/openspec/changes/jwt-upn-authorization/tasks.md
+++ b/openspec/changes/jwt-upn-authorization/tasks.md
@@ -1,0 +1,24 @@
+## 1. Remove JWT-claim roles from ApiKeyPrincipal
+
+- [x] 1.1 Remove `Collection<String> jwtRoles` parameter from `ApiKeyPrincipal` constructor (`src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipal.java`)
+- [x] 1.2 Remove the `setRoles(new TreeSet<>(jwtRoles))` call from the constructor body
+
+## 2. Remove roles extraction from ApiKeyPrincipalProvider
+
+- [x] 2.1 Remove the `roles` local variable declaration and `claims.getStringListClaim("roles")` call from `lookupAndCacheCredential()` (`src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProvider.java`)
+- [x] 2.2 Update the `new ApiKeyPrincipal(...)` call to remove the `roles` argument
+
+## 3. Remove AccessControlService fallback for JWT-claim roles
+
+- [x] 3.1 Remove the `ApiKeyPrincipal` instanceof check and its `getRoles().contains(role)` fallback from `AccessControlService.isUserInRole()` (`src/main/java/gov/cdc/izgateway/hub/service/accesscontrol/AccessControlService.java`)
+- [x] 3.2 Remove the `import gov.cdc.izgateway.hub.security.ApiKeyPrincipal` import from `AccessControlService.java` if it is no longer referenced
+
+## 4. Update tests
+
+- [x] 4.1 Update `ApiKeyPrincipalTests.java`: remove the `roles` parameter from the `principal(List<String> roles)` helper and update all callers to use the simplified constructor (`src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalTests.java`)
+- [x] 4.2 Remove or update the `rolesAreReturnedInTheFormatAccessControlValveExpects()` test in `ApiKeyPrincipalTests.java` — roles are always empty on `ApiKeyPrincipal`; replace with an assertion that `getRoles()` returns an empty set
+- [x] 4.3 Update `ApiKeyPrincipalProviderTests.java`: remove the `roles` claim from the JWT builder (line ~73) and replace the `assertThat(apiKey.getRoles()).contains("ads", "soap")` assertion (line ~103) with an assertion that `getRoles()` is empty (`src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProviderTests.java`)
+
+## 5. Verify
+
+- [x] 5.1 Run `mvn test` and confirm all tests pass

--- a/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipal.java
+++ b/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipal.java
@@ -4,9 +4,6 @@ import gov.cdc.izgateway.security.IzgPrincipal;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.Collection;
-import java.util.TreeSet;
-
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class ApiKeyPrincipal extends IzgPrincipal {
@@ -14,13 +11,12 @@ public class ApiKeyPrincipal extends IzgPrincipal {
     private String jti;
     private String upn;
 
-    public ApiKeyPrincipal(String sub, String jtiValue, Collection<String> jwtRoles, String upnValue, String issuerValue) {
+    public ApiKeyPrincipal(String sub, String jtiValue, String upnValue, String issuerValue) {
         setName(upnValue);
         setOrganization(sub);
         setJti(jtiValue);
         setUpn(upnValue);
         setIssuer(issuerValue);
-        setRoles(new TreeSet<>(jwtRoles));
     }
 
     @Override

--- a/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProvider.java
+++ b/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProvider.java
@@ -23,9 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 
 @Component
 @Slf4j
@@ -196,12 +194,6 @@ public class ApiKeyPrincipalProvider {
 
         if (credentialOpt.isPresent() && isUsableStatus(credentialOpt.get().getStatus())) {
             String sub = claims.getSubject();
-            List<String> roles;
-            try {
-                roles = claims.getStringListClaim("roles");
-            } catch (ParseException e) {
-                roles = Collections.emptyList();
-            }
             String upn = (String) claims.getClaim("upn");
             if (upn == null || upn.isBlank()) {
                 log.warn("JWT rejected: missing or blank upn claim for jti={}", jti);
@@ -211,7 +203,6 @@ public class ApiKeyPrincipalProvider {
             ApiKeyPrincipal principal = new ApiKeyPrincipal(
                     sub,
                     jti,
-                    roles != null ? roles : Collections.emptyList(),
                     upn,
                     config.getIssuer()
             );

--- a/src/main/java/gov/cdc/izgateway/hub/service/accesscontrol/AccessControlService.java
+++ b/src/main/java/gov/cdc/izgateway/hub/service/accesscontrol/AccessControlService.java
@@ -17,7 +17,6 @@ import gov.cdc.izgateway.hub.repository.IAllowedUserRepository;
 import gov.cdc.izgateway.hub.repository.IDenyListRecordRepository;
 import gov.cdc.izgateway.hub.repository.IFileTypeRepository;
 import gov.cdc.izgateway.hub.repository.RepositoryFactory;
-import gov.cdc.izgateway.hub.security.ApiKeyPrincipal;
 import gov.cdc.izgateway.logging.RequestContext;
 import gov.cdc.izgateway.logging.markers.Markers2;
 import gov.cdc.izgateway.model.IFileType;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -142,16 +142,7 @@ public class AccessControlService implements InitializingBean, IAccessControlSer
     
     @Override
 	public boolean isUserInRole(String user, String role) {
-		if (currentModelHelper.isUserInRole(user, role)) {
-			return true;
-		}
-		// For API key (JWT) principals, roles are carried in the token itself rather than
-		// the DynamoDB access control table. Fall back to the principal's role set.
-		var principal = RequestContext.getPrincipal();
-		if (principal instanceof ApiKeyPrincipal apiKeyPrincipal) {
-			return apiKeyPrincipal.getRoles().contains(role);
-		}
-		return false;
+		return currentModelHelper.isUserInRole(user, role);
     }
 
 	@Override
@@ -188,6 +179,8 @@ public class AccessControlService implements InitializingBean, IAccessControlSer
 		if (wasUserPreviouslyAdmitted(user, method, path)) {
 			return true;
 		}
+		log.debug("Access check: user={} roles={}", user,
+				Roles.values().stream().filter(r -> isUserInRole(user, r)).collect(Collectors.toSet()));
     	for (String role: roles) {
     		if (isUserInRole(user, role)) {
     			saveAdmittedUser(user, method, path);

--- a/src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProviderTests.java
+++ b/src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalProviderTests.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,8 +68,7 @@ class ApiKeyPrincipalProviderTest {
                 .subject("TEST_ORG")
                 .jwtID(jti)
                 .expirationTime(exp != null ? exp : Date.from(Instant.now().plus(Duration.ofDays(365))))
-                .claim("env", envId)
-                .claim("roles", List.of("ads", "soap"));
+                .claim("env", envId);
         if (upn != null) {
             claimsBuilder.claim("upn", upn);
         }
@@ -100,7 +98,7 @@ class ApiKeyPrincipalProviderTest {
         assertThat(apiKey.getUpn()).isEqualTo(TEST_UPN);
         assertThat(apiKey.getJti()).isEqualTo(TEST_JTI);
         assertThat(apiKey.getOrganization()).isEqualTo("TEST_ORG");
-        assertThat(apiKey.getRoles()).contains("ads", "soap");
+        assertThat(apiKey.getRoles()).isEmpty();
     }
 
     @Test

--- a/src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalTests.java
+++ b/src/test/java/gov/cdc/izgateway/hub/security/ApiKeyPrincipalTests.java
@@ -4,7 +4,6 @@ import gov.cdc.izgateway.security.IzgPrincipal;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,64 +14,55 @@ class ApiKeyPrincipalTest {
     private static final String UPN = "test.example.gov";
     private static final String ISSUER = "http://localhost:3000";
 
-    private ApiKeyPrincipal principal(List<String> roles) {
-        return new ApiKeyPrincipal(SUB, JTI, roles, UPN, ISSUER);
+    private ApiKeyPrincipal principal() {
+        return new ApiKeyPrincipal(SUB, JTI, UPN, ISSUER);
     }
 
     @Test
-    void rolesAreReturnedInTheFormatAccessControlValveExpects() {
-        ApiKeyPrincipal p = principal(List.of("ads", "soap"));
-
-        assertThat(p.getRoles()).containsExactlyInAnyOrder("ads", "soap");
+    void rolesAreAlwaysEmpty() {
+        assertThat(principal().getRoles()).isEmpty();
     }
 
     @Test
     void subjectIsExposedAsOrganization() {
-        assertThat(principal(List.of()).getOrganization()).isEqualTo(SUB);
+        assertThat(principal().getOrganization()).isEqualTo(SUB);
     }
 
     @Test
     void upnIsCarriedAsName() {
-        assertThat(principal(List.of()).getName()).isEqualTo(UPN);
+        assertThat(principal().getName()).isEqualTo(UPN);
     }
 
     @Test
     void jtiFieldIsSet() {
-        assertThat(principal(List.of()).getJti()).isEqualTo(JTI);
+        assertThat(principal().getJti()).isEqualTo(JTI);
     }
 
     @Test
     void upnFieldIsSet() {
-        assertThat(principal(List.of()).getUpn()).isEqualTo(UPN);
+        assertThat(principal().getUpn()).isEqualTo(UPN);
     }
 
     @Test
     void issuerFieldIsSet() {
-        assertThat(principal(List.of()).getIssuer()).isEqualTo(ISSUER);
+        assertThat(principal().getIssuer()).isEqualTo(ISSUER);
     }
 
     @Test
     void isInstanceOfIzgPrincipalAndJavaPrincipal() {
-        ApiKeyPrincipal p = principal(List.of("ads"));
-
-        assertThat(p).isInstanceOf(IzgPrincipal.class);
-        assertThat(p).isInstanceOf(Principal.class);
+        assertThat(principal()).isInstanceOf(IzgPrincipal.class);
+        assertThat(principal()).isInstanceOf(Principal.class);
     }
 
     @Test
     void serialNumberHexReturnsJti() {
         // ApiKeyPrincipal uses jti as the serial number equivalent (differs from cert-backed principals)
-        assertThat(principal(List.of()).getSerialNumberHex()).isEqualTo(JTI);
-    }
-
-    @Test
-    void emptyRolesYieldsEmptySet() {
-        assertThat(principal(List.of()).getRoles()).isEmpty();
+        assertThat(principal().getSerialNumberHex()).isEqualTo(JTI);
     }
 
     @Test
     void nullSubjectIsTolerated() {
-        ApiKeyPrincipal p = new ApiKeyPrincipal(null, JTI, List.of("ads"), UPN, ISSUER);
+        ApiKeyPrincipal p = new ApiKeyPrincipal(null, JTI, UPN, ISSUER);
 
         assertThat(p.getOrganization()).isNull();
     }

--- a/src/test/java/gov/cdc/izgateway/hub/security/AuthenticationEnforcementFilterTests.java
+++ b/src/test/java/gov/cdc/izgateway/hub/security/AuthenticationEnforcementFilterTests.java
@@ -45,7 +45,7 @@ class AuthenticationEnforcementFilterTest {
 
     @Test
     void authenticatedPrincipal_continuesFilterChain() throws Exception {
-        ApiKeyPrincipal principal = new ApiKeyPrincipal("ORG", "jti-123", java.util.List.of("ads"), "dns.example.gov", "http://issuer");
+        ApiKeyPrincipal principal = new ApiKeyPrincipal("ORG", "jti-123", "dns.example.gov", "http://issuer");
         when(principalService.getPrincipal(request)).thenReturn(principal);
 
         filter.doFilterInternal(request, response, filterChain);


### PR DESCRIPTION
The authorization will happen using the UPN (DNS) in the JWT just like we use common name in mTLS certs for authorization.