### PR TITLE
IGDD-3138: bump izgw-bom to 1.12.0 to fix jackson-core CVE (GHSA-r7wm…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.12.0</version>
+        <version>1.13.0-SNAPSHOT</version>
         <relativePath />
 	</parent>
 	<artifactId>izgw-hub</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.11.0-SNAPSHOT</version>
+        <version>1.12.0</version>
         <relativePath />
 	</parent>
 	<artifactId>izgw-hub</artifactId>


### PR DESCRIPTION
jackson-core's version is managed by the izgw-bom parent via ${jackson.version}. Released izgw-bom 1.12.0 already pins jackson.version=2.22.1, so bumping hub's parent from 1.11.0-SNAPSHOT to 1.12.0 resolves jackson-core to 2.22.1. This also aligns hub with izgw-transform, which already uses BOM 1.12.0.

Other managed versions moved (patch-level only): aws-sdk 2.47.0->2.47.1, camel 4.18.2->4.18.3. Verified via `mvn dependency:list` (jackson-core:2.22.1).