### PR TITLE
 Reconciling OpenSpec to latest changes in IGDD-3140

### DIFF
--- a/openspec/changes/README.md
+++ b/openspec/changes/README.md
@@ -1,0 +1,69 @@
+# Active OpenSpec Changes — Reading Guide
+
+## How to read this directory
+
+This directory holds **deltas**, not current-state requirements. Each change contains
+`## ADDED / MODIFIED / REMOVED Requirements` sections describing what that change alters.
+A change is a point-in-time proposal: it records what was reviewed and approved *then*.
+
+Current-state requirements live in `openspec/specs/`. When a change is implemented and
+archived, its deltas are applied into `openspec/specs/` and the change moves to
+`changes/archive/` as history.
+
+> **Important caveat today:** `openspec/specs/` currently contains only the ADS metadata
+> specs (`compute-*.md`, `filename-validation.md`). **No API-key capability has been synced
+> yet**, because the API-key chain is still mid-implementation. Until it is archived, the
+> change directories below are the only description of API-key authentication — so they must
+> be read as a **stack**, in order, not individually. Reading any one of them alone will give
+> you a stale picture.
+
+Do not "fix" an older change's delta to match a newer decision. Doing so destroys the
+approval record and leaves the newer change's `## MODIFIED Requirements` block modifying
+text that no longer exists. Later deltas supersede earlier ones by design.
+
+## The API-key authentication stack
+
+Read in this order. Later entries supersede earlier ones.
+
+| # | Change | Jira | Implementation state |
+|---|--------|------|----------------------|
+| 1 | `igdd-2705-api-key-principal-provider` | IGDD-2705 | Mostly shipped; tasks 1.1, 1.2, 4.5–4.7, 9.5, 9.9 **re-opened** by the IGDD-3140 model change |
+| 2 | `igdd-2711-grace-period-revocation` | IGDD-2711 | Mostly shipped; tasks 1.2, 1.3, 6.1 **re-opened** by the same |
+| 3 | `jwt-upn-authorization` | — | Fully implemented and merged to `develop` |
+
+### Net current model (what the stack actually says)
+
+- **Sort key is `{jti}` alone** — no environment prefix. Lookup is
+  `ApiKeyCredentialRepository.findByJti(jti)`.
+- **The JWT is identity-only**: `iss`, `kid` (header), `jti`, `sub` (jurisdictionId), `upn`,
+  `iat`, `exp`. There is **no `env` claim** and **no usable `roles` claim**.
+- **Environment authorization is server-side** — an `environments` list on the
+  `ApiKeyCredential` record, checked at routing time against `SystemUtils.getDestType()`.
+- **Roles do not come from the token.** Entry 3 removed JWT-claim roles entirely.
+  `ApiKeyPrincipal` carries no roles; `AccessControlValve` resolves roles from the DynamoDB
+  AccessGroup table keyed on `principal.getName()` — the `upn` for JWT callers, the CN for
+  mTLS callers. Entry 1's delta still shows the old `roles` → principal mapping; that is
+  history, superseded by entry 3.
+- **Usable statuses** are `active` and `grace_period`. `expired` is not stored — it is
+  derived on the Console side.
+
+### Known gap: use-type enforcement
+
+The stack does **not** cover `credential.useTypes ∩ destination Jurisdiction.allowedUseTypes`.
+That enforcement is tracked under **IGDD-3257** (*IZG Hub: Enhancement to API-key
+authentication with useTypes*), which also owns the new `izgw-core` SecurityFault. See
+`igdd-2705-api-key-principal-provider/design.md` § D10 for the model and why it is deferred.
+Related: **IGDD-3258** (DynamoDB API-key data migration & sender seeding).
+
+### Archiving
+
+The three changes above must be archived **as a unit**, after the IGDD-3140 code rework
+lands and the re-opened tasks close. They cannot be split: entry 3 *modifies* a requirement
+that entry 1 *adds*, so until entry 1 is in `openspec/specs/` there is nothing for entry 3 to
+modify.
+
+## Other active changes
+
+| Change | Jira | Notes |
+|--------|------|-------|
+| `fix-ndlp-folder-paths` | — | Has no `specs/` deltas, so `openspec validate` reports it as failing. Pre-existing; unrelated to the API-key work. |

--- a/openspec/changes/igdd-2705-api-key-principal-provider/design.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/design.md
@@ -55,12 +55,10 @@ When Hub is configured with `server.ssl.client-auth=want` (required to accept JW
 ### D5 — Revocation propagates `jti` via existing SQS refresh mechanism
 `DbController`'s `/rest/refresh?all=true` endpoint and `RefreshQueueService` already propagate refresh events to all Hub instances via SQS. Config Console calls this endpoint after marking a `jti` revoked. Hub's `ApiKeyPrincipalProvider` subscribes to the refresh event, evicts the `jti` from `credentialCache`, and inserts a REVOKED sentinel with TTL = max token lifetime — ensuring no subsequent cache miss can re-validate the revoked credential. No new SQS topic or SNS resource is needed.
 
-### D7 — `env` claim is a numeric integer, not a string
-The JWT `env` claim carries the environment as a numeric ID matching `SystemUtils.getDestType()` (1=Production, 2=Testing, 3=Onboarding, 4=Staging, 5=Development) rather than the human-readable string name (e.g., `"Development"`). Hub parses the claim as a `Number` and compares it to `SystemUtils.getDestType()` directly. A missing or non-numeric `env` claim is rejected.
+### D7 — Environment authorization is a server-side `environments` list, not a JWT claim
+The environment(s) a credential is valid in are stored on the `ApiKeyCredential` record as a server-side `environments` list — numeric IDs from the IZG `Environment` enumeration (1=PRODUCTION, 2=TEST, 3=ONBOARD, 4=STAGE, 5=DEV, 6=UNKNOWN) — and are **not** carried in the JWT. At routing time Hub looks the credential up by `jti` and validates that its own environment (`SystemUtils.getDestType()`) is contained in the credential's `environments` list; a request whose target environment is absent from the list is rejected (`null` → 401). Standard sender credentials contain exactly one environment ID; admin/operational credentials MAY contain several.
 
-The numeric form is required for referential integrity with other IZG database tables that key on the numeric environment identifier. The string-name form used in the original ADR examples was an implicit choice that was not evaluated against the data model; this decision supersedes it. Config Console must emit the numeric ID when signing JWTs.
-
-The `env` string passed internally to `ApiKeyCredentialRepository.findByEnvAndJti()` is `String.valueOf(envInt)` (e.g., `"5"`), so DynamoDB sort keys take the form `5#<jti>` rather than `Development#<jti>`.
+Keeping the permitted environments server-side (rather than in the token) lets the set change under access-control review without reissuing the credential — the same rationale that keeps `useTypes` off the token. Because the environment is not part of the credential's identity, the DynamoDB sort key is simply `{jti}` with no environment prefix; `ApiKeyCredentialRepository.findByJti(jti)` reads the record directly by `jti`.
 
 ### D6 — `jwt.test-secret` property bypasses Secrets Manager for local dev
 When `jwt.test-secret` is set, `ApiKeyPrincipalProvider` uses that secret for all `kid` values instead of calling Secrets Manager. This allows local testing without AWS credentials. The property must not be set in non-local profiles.

--- a/openspec/changes/igdd-2705-api-key-principal-provider/design.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/design.md
@@ -60,6 +60,49 @@ The environment(s) a credential is valid in are stored on the `ApiKeyCredential`
 
 Keeping the permitted environments server-side (rather than in the token) lets the set change under access-control review without reissuing the credential — the same rationale that keeps `useTypes` off the token. Because the environment is not part of the credential's identity, the DynamoDB sort key is simply `{jti}` with no environment prefix; `ApiKeyCredentialRepository.findByJti(jti)` reads the record directly by `jti`.
 
+### D10 — Use-type authorization is server-side, and its enforcement is deferred to IGDD-3257
+
+> **Context only — this change specifies no use-type behaviour.** Recorded here so the
+> authorization model can be read whole from one place; the requirements and code land under
+> IGDD-3257.
+
+Alongside `environments`, IGDD-3140 defines a second server-side authorization property on the
+credential: `useTypes` — the categories of immunization data a sender is authorized to submit,
+drawn from the enumeration `PATIENT | PROVIDER | PUBLIC_HEALTH`. It is stored on the
+`ApiKeyCredential` record (as a DynamoDB String Set) and is **not** carried in the JWT, for the
+same reason `environments` is not: policy can then change under access-control review without
+reissuing the credential.
+
+The counterpart property is `allowedUseTypes` on the **destination** `Jurisdiction` record —
+the categories that jurisdiction has opted to accept. The authorization rule is an intersection
+evaluated **at routing time, not at issuance**:
+
+```
+credential.useTypes ∩ destination.jurisdiction.allowedUseTypes ≠ ∅
+```
+
+An empty intersection rejects the message. An empty `allowedUseTypes` on the destination is
+therefore **deny-all** for API-key senders. The check is per-destination, not per-credential: a
+sender's credential is bound to its own `jurisdictionId`, but it may transmit to many
+destinations, so the same credential can be authorized for one destination and rejected by the
+next. Rejection must surface as a new `izgw-core` `SecurityFault` — a clear, logged
+authorization error, not a silent drop.
+
+**Why this change does not implement it.** 2705 establishes the credential registry and the
+authentication path (signature, claims, `status`, `environments`). Use-type enforcement needs
+two things 2705 does not touch: a `useTypes` field on `ApiKeyCredential`, an `allowedUseTypes`
+field on `Jurisdiction`, and a new fault type in `izgw-core`. IGDD-3140's own jurisdiction-policy
+spec defers it to a separate izgw-hub + izgw-core ticket, which is **IGDD-3257**. That ticket
+also carries the `active`/`grace_period` usable-status rule, which overlaps the
+`igdd-2711-grace-period-revocation` delta on the same requirement — so 3257 is expected to
+supersede the "DynamoDB credential status check" requirement wholesale rather than add a fourth
+delta layer to it.
+
+**Consequence for deployment order.** Until 3257 ships, an API-key sender that passes
+authentication can route to any destination its `AllowedUser` entries permit, with no use-type
+restriction. Jurisdictions relying on use-type scoping as an access control are not yet
+protected by it.
+
 ### D6 — `jwt.test-secret` property bypasses Secrets Manager for local dev
 When `jwt.test-secret` is set, `ApiKeyPrincipalProvider` uses that secret for all `kid` values instead of calling Secrets Manager. This allows local testing without AWS credentials. The property must not be set in non-local profiles.
 

--- a/openspec/changes/igdd-2705-api-key-principal-provider/proposal.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/proposal.md
@@ -23,6 +23,19 @@ IZ Gateway Hub currently authenticates callers exclusively via mTLS client certi
 
 ### Modified Capabilities
 
+### Out of Scope — use-type enforcement
+
+This change reconciles only the `environments` half of the IGDD-3140 authorization model.
+The second half — enforcing `credential.useTypes ∩ destination Jurisdiction.allowedUseTypes ≠ ∅`
+at routing time, with an empty `allowedUseTypes` meaning deny-all, and rejection surfacing as a
+new `izgw-core` `SecurityFault` — is **not specified or implemented here**. It requires a
+`useTypes` field on `ApiKeyCredential`, an `allowedUseTypes` field on `Jurisdiction`, and a new
+core fault type, none of which this change touches.
+
+Tracked under **IGDD-3257** (*IZG Hub: Enhancement to API-key authentication with useTypes*).
+See `design.md` § D10 for the model, the rationale for keeping `useTypes` server-side, and the
+interim exposure while 3257 is outstanding.
+
 ## Impact
 
 - **`HubPrincipalService`** — auth chain updated; JWT-only clients now supported with `client-auth=want`

--- a/openspec/changes/igdd-2705-api-key-principal-provider/proposal.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/proposal.md
@@ -4,8 +4,8 @@ IZ Gateway Hub currently authenticates callers exclusively via mTLS client certi
 
 ## What Changes
 
-- **New**: `ApiKeyCredential` DynamoDB entity — credential registry entry keyed by `env#jti`; stores `status` (active/revoked), `jurisdictionId`, `issuedAt`, `expiresAt`
-- **New**: `ApiKeyCredentialRepository` — DynamoDB repository for `ApiKeyCredential` lookup by `env` and `jti`
+- **New**: `ApiKeyCredential` DynamoDB entity — credential registry entry keyed by `jti`; stores `status` (active/revoked), `environments` (server-side list), `jurisdictionId`, `issuedAt`, `expiresAt`
+- **New**: `ApiKeyCredentialRepository` — DynamoDB repository for `ApiKeyCredential` lookup by `jti`
 - **New**: `ApiKeyPrincipal` — extends `IzgPrincipal`; carries `jurisdictionId` (from `sub`), `roles`, `dns`, and `jti` from a validated HS256 JWT
 - **New**: `ApiKeyPrincipalProvider` — validates HS256 JWTs; uses a secret cache (`kid` → Secrets Manager version) and a credential cache (`jti` → `ApiKeyPrincipal` or REVOKED sentinel); falls back gracefully to cert auth
 - **New**: `JwtConfig` — `@ConfigurationProperties(prefix="jwt")` binding for `jwt.issuer`, `jwt.secrets-manager-secret-name`, secret-cache TTL, and credential-cache TTL
@@ -18,8 +18,8 @@ IZ Gateway Hub currently authenticates callers exclusively via mTLS client certi
 
 ### New Capabilities
 
-- `api-key-principal-provider`: HS256 JWT validation flow — header parsing, `kid`-based Secrets Manager secret lookup with in-memory cache, signature verification, claims validation (`exp`, `env`, `iss`), `jti` credential registry check against DynamoDB with in-memory cache, REVOKED sentinel logic, and `ApiKeyPrincipal` construction
-- `api-key-credential`: DynamoDB entity representing a registered API key credential — lifecycle (active/revoked/expired), sort-key structure, and repository contract for Hub's credential validation path
+- `api-key-principal-provider`: HS256 JWT validation flow — header parsing, `kid`-based Secrets Manager secret lookup with in-memory cache, signature verification, claims validation (`exp`, `iss`), `jti` credential registry check against DynamoDB with in-memory cache, server-side `environments` check, REVOKED sentinel logic, and `ApiKeyPrincipal` construction
+- `api-key-credential`: DynamoDB entity representing a registered API key credential — lifecycle (active/revoked), sort-key structure, and repository contract for Hub's credential validation path
 
 ### Modified Capabilities
 
@@ -27,7 +27,7 @@ IZ Gateway Hub currently authenticates callers exclusively via mTLS client certi
 
 - **`HubPrincipalService`** — auth chain updated; JWT-only clients now supported with `client-auth=want`
 - **`DbController` / `RefreshQueueService`** — revocation propagation extended to carry `jti`
-- **DynamoDB shared table** — two new entity types: `ApiKeyCredential` (sort key `env#jti`), used by Hub; `ApiKeyDomain` (sort key `env#domain`) is Config Console's concern and not touched here
+- **DynamoDB shared table** — two new entity types: `ApiKeyCredential` (sort key `jti`), used by Hub; `ApiKeyDomain` (sort key `env#domain`) is Config Console's concern and not touched here
 - **AWS Secrets Manager** — Hub IAM task role needs `secretsmanager:GetSecretValue` on `/izg/{env}/jwt/signing-secret`
 - **`izgw-core`** — no changes; `JwtTokenExtractor` and `IzgPrincipal` from core are reused as-is
 - **Dependencies** — `com.nimbusds:nimbus-jose-jwt` (already on classpath via Spring Security), `com.github.ben-manes.caffeine:caffeine` (already on classpath)

--- a/openspec/changes/igdd-2705-api-key-principal-provider/specs/api-key-credential/spec.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/specs/api-key-credential/spec.md
@@ -1,12 +1,12 @@
 ## ADDED Requirements
 
 ### Requirement: ApiKeyCredential entity structure
-`ApiKeyCredential` SHALL be a DynamoDB entity following Hub's single-table design. It SHALL extend `DynamoDbAudit` and be annotated with `@DynamoDbBean`. Its sort key SHALL be `{env}#{jti}`, where `env` is the environment name and `jti` is the UUID token identifier.
+`ApiKeyCredential` SHALL be a DynamoDB entity following Hub's single-table design. It SHALL extend `DynamoDbAudit` and be annotated with `@DynamoDbBean`. Its sort key SHALL be `{jti}` — the credential's UUID token identifier alone, with no environment prefix. The entity class name (`ApiKeyCredential`) is the `entityType` attribute, per Hub's single-table convention.
 
 Required fields:
 - `jti` — String; the JWT `jti` claim; unique credential identifier
-- `env` — String; the environment name (e.g., `Production`, `Onboarding`)
-- `status` — String; one of `active`, `revoked`, `expired`
+- `environments` — List of numeric environment IDs (`number[]`, values 1–6 per the IZG `Environment` enumeration); the environments in which the credential is valid. Standard credentials contain exactly one ID; admin/operational credentials MAY contain several. Environment authorization is a server-side property read from this list — it is NOT carried in the JWT.
+- `status` — String; one of `active`, `revoked` (a renewed key also sits in `grace_period` — see IGDD-2711)
 - `jurisdictionId` — String; the jurisdiction the credential was issued to (from JWT `sub`); stored as a string representation of an integer to match the legacy IZG jurisdiction identifier scheme (e.g., `"42"`)
 - `issuedAt` — `Instant`; when the credential was issued (serialized via `InstantAsStringAttributeConverter`)
 - `expiresAt` — `Instant`; when the credential expires (serialized via `InstantAsStringAttributeConverter`)
@@ -14,19 +14,15 @@ Required fields:
 - `revokedBy` — String (nullable); identity of the revoking operator
 
 #### Scenario: Entity persisted by Config Console is readable by Hub
-- **WHEN** Config Console writes an `ApiKeyCredential` record with `status = active` using sort key `Production#<jti>`
-- **THEN** Hub's repository can read that record by `env = Production` and `jti = <jti>` and deserialize it without error
+- **WHEN** Config Console writes an `ApiKeyCredential` record with `status = active` using sort key `<jti>`
+- **THEN** Hub's repository can read that record by `jti = <jti>` and deserialize it without error
 
 ### Requirement: ApiKeyCredential sort key format
-The `sortKey` SHALL be formatted as `{env}#{jti}` where `{env}` is the **numeric environment ID as a string** (e.g., `"1"` for Production, `"5"` for Development) and `{jti}` is the credential's UUID. Using the numeric ID provides referential integrity with other tables that key on the numeric environment identifier.
+The `sortKey` SHALL be formatted as `{jti}`, the credential's UUID, with no environment prefix. The Hub reads a credential directly by `jti`; the environments a credential is valid for are stored in the `environments` attribute rather than encoded in the key, so that set can change (subject to access-control review) without rewriting the key.
 
-#### Scenario: Sort key for Production environment
-- **WHEN** an `ApiKeyCredential` is created for `env = 1` (Production) and `jti = 018f4e2a-5678-7abc-8def-000000000002`
-- **THEN** its `sortKey` value is `1#018f4e2a-5678-7abc-8def-000000000002`
-
-#### Scenario: Sort key for Development environment
-- **WHEN** an `ApiKeyCredential` is created for `env = 5` (Development) and `jti = 018f4e2a-5678-7abc-8def-000000000002`
-- **THEN** its `sortKey` value is `5#018f4e2a-5678-7abc-8def-000000000002`
+#### Scenario: Sort key is the jti alone
+- **WHEN** an `ApiKeyCredential` is created with `jti = 018f4e2a-5678-7abc-8def-000000000002`
+- **THEN** its `sortKey` value is `018f4e2a-5678-7abc-8def-000000000002`
 
 ### Requirement: Instant date serialization
 `issuedAt` and `expiresAt` fields of type `Instant` SHALL be serialized to DynamoDB as ISO-8601 strings with UTC `Z` suffix (e.g., `2025-06-04T00:00:00Z`) using `InstantAsStringAttributeConverter`. This is distinct from the `Date` fields inherited from `DynamoDbAudit` (which use a custom `DateConverter` with millisecond format `yyyy-MM-dd'T'HH:mm:ss.SSSXX`). Both formats must coexist without conflict.
@@ -35,17 +31,17 @@ The `sortKey` SHALL be formatted as `{env}#{jti}` where `{env}` is the **numeric
 - **WHEN** an `ApiKeyCredential` is written with `issuedAt = 2025-06-04T00:00:00Z`
 - **THEN** reading it back from DynamoDB returns an `Instant` equal to `2025-06-04T00:00:00Z` (no precision loss, no null)
 
-### Requirement: ApiKeyCredentialRepository lookup by env and jti
-`ApiKeyCredentialRepository` SHALL provide a `findByEnvAndJti(String env, String jti)` method that returns `Optional<ApiKeyCredential>`. The method SHALL construct the sort key as `{env}#{jti}` and perform a DynamoDB `GetItem` using the `DynamoDbEnhancedClient`. An empty `Optional` SHALL be returned if no record exists.
+### Requirement: ApiKeyCredentialRepository lookup by jti
+`ApiKeyCredentialRepository` SHALL provide a `findByJti(String jti)` method that returns `Optional<ApiKeyCredential>`. The method SHALL use the sort key `{jti}` and perform a DynamoDB `GetItem` using the `DynamoDbEnhancedClient`. An empty `Optional` SHALL be returned if no record exists.
 
 #### Scenario: Active credential lookup
-- **WHEN** `findByEnvAndJti("Production", "<jti>")` is called and a matching active record exists
+- **WHEN** `findByJti("<jti>")` is called and a matching active record exists
 - **THEN** the method returns `Optional.of(credential)` with `status = active`
 
 #### Scenario: Missing credential lookup
-- **WHEN** `findByEnvAndJti("Production", "<unknown-jti>")` is called and no matching record exists
+- **WHEN** `findByJti("<unknown-jti>")` is called and no matching record exists
 - **THEN** the method returns `Optional.empty()`
 
 #### Scenario: Revoked credential lookup
-- **WHEN** `findByEnvAndJti("Production", "<jti>")` is called and the record has `status = revoked`
+- **WHEN** `findByJti("<jti>")` is called and the record has `status = revoked`
 - **THEN** the method returns `Optional.of(credential)` with `status = revoked`

--- a/openspec/changes/igdd-2705-api-key-principal-provider/specs/api-key-principal-provider/spec.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/specs/api-key-principal-provider/spec.md
@@ -55,27 +55,20 @@ Hub SHALL verify the JWT's HMAC-SHA256 signature against the secret retrieved fo
 ### Requirement: Claims validation
 After successful signature verification, Hub SHALL validate the following claims in order. Any failure SHALL cause the provider to return `null`:
 1. `exp` has not passed (with a configurable clock skew tolerance, default 30 seconds)
-2. `env` is present, is a numeric integer, and its value matches `SystemUtils.getDestType()` (e.g., `5` for Development, `1` for Production). A missing or non-numeric `env` claim SHALL be rejected.
-3. `iss` matches the configured `jwt.issuer` (re-validated against the decoded payload)
+2. `iss` matches the configured `jwt.issuer` (re-validated against the decoded payload)
+
+The token does NOT carry an `env` claim. Environment authorization is a server-side property of the credential and is enforced later against the credential's `environments` list (see "DynamoDB credential status check").
 
 #### Scenario: Expired token
 - **WHEN** the current time exceeds the JWT `exp` claim (beyond the clock-skew tolerance)
 - **THEN** `ApiKeyPrincipalProvider` returns `null`
 
-#### Scenario: Wrong environment
-- **WHEN** the JWT `env` claim (numeric) does not match Hub's `SystemUtils.getDestType()` value
-- **THEN** `ApiKeyPrincipalProvider` returns `null`
-
-#### Scenario: Non-numeric environment
-- **WHEN** the JWT `env` claim is absent or is a string (e.g., `"Development"`)
-- **THEN** `ApiKeyPrincipalProvider` returns `null`
-
 #### Scenario: Valid claims
-- **WHEN** `exp` is in the future, `env` is numeric and matches, and `iss` matches
+- **WHEN** `exp` is in the future and `iss` matches
 - **THEN** credential cache lookup proceeds
 
 ### Requirement: Credential cache lookup by `jti`
-Hub SHALL maintain an in-memory credential cache keyed by `jti`. On a cache hit, the cached value (an `ApiKeyPrincipal` or REVOKED sentinel) SHALL be returned immediately without a DynamoDB call. On a cache miss, Hub SHALL query DynamoDB for the `ApiKeyCredential` record with sort key `env#jti`.
+Hub SHALL maintain an in-memory credential cache keyed by `jti`. On a cache hit, the cached value (an `ApiKeyPrincipal` or REVOKED sentinel) SHALL be returned immediately without a DynamoDB call. On a cache miss, Hub SHALL query DynamoDB for the `ApiKeyCredential` record with sort key `{jti}`.
 
 #### Scenario: Credential cache hit — active
 - **WHEN** the `jti` is in the credential cache as an `ApiKeyPrincipal`
@@ -87,7 +80,7 @@ Hub SHALL maintain an in-memory credential cache keyed by `jti`. On a cache hit,
 
 #### Scenario: Credential cache miss
 - **WHEN** the `jti` is not in the credential cache
-- **THEN** Hub reads the `ApiKeyCredential` record from DynamoDB by sort key `env#jti`
+- **THEN** Hub reads the `ApiKeyCredential` record from DynamoDB by sort key `{jti}`
 
 ### Requirement: `upn` claim validation
 After signature and standard claims verification, Hub SHALL extract the `upn` claim from the verified JWT payload. If `upn` is absent or blank, Hub SHALL log a warning and return `null`, rejecting the token. A non-blank `upn` is required for the principal to be usable in `AllowedUser` authorization lookups.
@@ -106,19 +99,23 @@ After signature and standard claims verification, Hub SHALL extract the `upn` cl
 
 ### Requirement: DynamoDB credential status check
 When the credential cache misses, Hub SHALL read the `ApiKeyCredential` record and act on its `status`:
-- **active**: construct an `ApiKeyPrincipal` from JWT claims (`upn` → `name` (IzgPrincipal.getName()), `sub` → `organization` (a numeric string jurisdiction ID, e.g., `"42"`), `roles` → roles, `jti` → jti), store in credential cache with `jwt.credential-cache-ttl` (default 5 minutes), and return the principal.
-- **revoked**, **expired**, or record absent: store a REVOKED sentinel in credential cache with TTL equal to the maximum possible token lifetime (1 year), and return `null`.
+- **active**: validate that the request's target environment (`SystemUtils.getDestType()`) is contained in the credential's server-side `environments` list; if it is not, return `null`. Otherwise construct an `ApiKeyPrincipal` from JWT claims (`upn` → `name` (IzgPrincipal.getName()), `sub` → `organization` (a numeric string jurisdiction ID, e.g., `"42"`), `roles` → roles, `jti` → jti), store in credential cache with `jwt.credential-cache-ttl` (default 5 minutes), and return the principal.
+- **revoked** or record absent: store a REVOKED sentinel in credential cache with TTL equal to the maximum possible token lifetime (1 year), and return `null`.
 
 #### Scenario: Active credential
-- **WHEN** DynamoDB returns `status = active` for the `jti`
+- **WHEN** DynamoDB returns `status = active` for the `jti` and the request's target environment is in the credential's `environments` list
 - **THEN** an `ApiKeyPrincipal` is constructed from JWT claims with `name = upn` and cached with 5-minute TTL, then returned
+
+#### Scenario: Credential not valid for the target environment
+- **WHEN** DynamoDB returns `status = active` for the `jti` but the request's target environment (`SystemUtils.getDestType()`) is NOT in the credential's `environments` list
+- **THEN** `ApiKeyPrincipalProvider` returns `null`, resulting in 401
 
 #### Scenario: Revoked credential
 - **WHEN** DynamoDB returns `status = revoked` for the `jti`
 - **THEN** a REVOKED sentinel is cached with max-token-lifetime TTL and `null` is returned, resulting in 401
 
 #### Scenario: Absent credential record
-- **WHEN** DynamoDB has no `ApiKeyCredential` record for `env#jti`
+- **WHEN** DynamoDB has no `ApiKeyCredential` record for `{jti}`
 - **THEN** the `jti` is cached in the absent cache (5-minute TTL) and `null` is returned. A shorter TTL is used (vs. the 366-day revoked TTL) to allow a credential record to be created after a cold-cache miss without permanent lockout.
 
 ### Requirement: Revocation propagation via refresh endpoint

--- a/openspec/changes/igdd-2705-api-key-principal-provider/tasks.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/tasks.md
@@ -1,7 +1,7 @@
 ## 1. DynamoDB Entity and Repository
 
-- [x] 1.1 Create `ApiKeyCredential.java` in `gov.cdc.izgateway.dynamodb.model` — `@DynamoDbBean` extending `DynamoDbAudit`; fields: `jti`, `env`, `status`, `jurisdictionId`, `issuedAt` (`Instant`), `expiresAt` (`Instant`), `revokedAt` (`Instant`, nullable), `revokedBy` (String, nullable); sort key `ApiKeyCredential#{env}#{jti}`
-- [x] 1.2 Create `ApiKeyCredentialRepository.java` in `gov.cdc.izgateway.dynamodb.repository` — extends `DynamoDbRepository<ApiKeyCredential>`; implement `findByEnvAndJti(String env, String jti)` returning `Optional<ApiKeyCredential>` via `DynamoDbEnhancedClient` GetItem
+- [ ] 1.1 Create `ApiKeyCredential.java` in `gov.cdc.izgateway.dynamodb.model` — `@DynamoDbBean` extending `DynamoDbAudit`; fields: `jti`, `environments` (List of numeric env IDs), `status`, `jurisdictionId`, `issuedAt` (`Instant`), `expiresAt` (`Instant`), `revokedAt` (`Instant`, nullable), `revokedBy` (String, nullable); sort key `{jti}`
+- [ ] 1.2 Create `ApiKeyCredentialRepository.java` in `gov.cdc.izgateway.dynamodb.repository` — extends `DynamoDbRepository<ApiKeyCredential>`; implement `findByJti(String jti)` returning `Optional<ApiKeyCredential>` via `DynamoDbEnhancedClient` GetItem on sort key `{jti}`
 - [x] 1.3 Register `ApiKeyCredential` in `DynamoDbRepositoryFactory` so it is included in table scanning and repository wiring
 
 ## 2. ApiKeyPrincipal
@@ -19,9 +19,9 @@
 - [x] 4.2 Implement `getPrincipal(HttpServletRequest)` — step 1: extract Bearer token via `JwtTokenExtractor`; return `null` on absent/non-Bearer header; step 2: parse JWT header only (use `com.nimbusds.jwt.SignedJWT.parse()`) to extract `kid`, `alg`, `iss`; return `null` if `alg != HS256`, `kid` is blank, or `iss` doesn't match `jwt.issuer`
 - [x] 4.3 Implement secret resolution — check `secretCache` by `kid`; on miss, call `SecretsManagerClient.getSecretValue(req -> req.secretId(config.secretsManagerSecretName()).versionId(kid))`; if `jwt.test-secret` is set, skip SM and use that value for all kids; cache the secret; return `null` if SM throws `ResourceNotFoundException`
 - [x] 4.4 Implement HS256 signature verification — create `MACVerifier(secretBytes)` from `com.nimbusds.jose`; call `signedJwt.verify(verifier)`; return `null` on failure
-- [x] 4.5 Implement claims validation — after successful verification, extract payload claims; validate: (a) `exp` not passed (allow 30s clock skew), (b) `env` claim is present, is a numeric integer, and its value matches `SystemUtils.getDestType()` — absent or non-numeric `env` is rejected, (c) `iss` matches `jwt.issuer`; return `null` on any failure
-- [x] 4.6 Implement credential cache lookup — check `credentialCache` by `jti`; on hit, return cached `ApiKeyPrincipal` (or `null` if value is `Boolean.TRUE` REVOKED sentinel); on miss, call `apiKeyCredentialRepository.findByEnvAndJti(env, jti)`
-- [x] 4.7 Implement DynamoDB status handling — if `status == active`: construct `ApiKeyPrincipal`, store in `credentialCache` (5m TTL), return principal; if absent: store in `absentCache` (5m TTL), return `null`; if `status != active`: store in `revokedCache` (366d TTL), return `null`
+- [ ] 4.5 Implement claims validation — after successful verification, extract payload claims; validate: (a) `exp` not passed (allow 30s clock skew), (b) `iss` matches `jwt.issuer`; return `null` on any failure. (Environment is NOT a claim — it is checked against the credential's server-side `environments` list after lookup, task 4.7.)
+- [ ] 4.6 Implement credential cache lookup — check `credentialCache` by `jti`; on hit, return cached `ApiKeyPrincipal` (or `null` if value is `Boolean.TRUE` REVOKED sentinel); on miss, call `apiKeyCredentialRepository.findByJti(jti)`
+- [ ] 4.7 Implement DynamoDB status handling — if `status == active` AND the request's target environment (`SystemUtils.getDestType()`) is in the credential's `environments` list: construct `ApiKeyPrincipal`, store in `credentialCache` (5m TTL), return principal; if the record is absent, or the credential is `active` but the target environment is NOT in `environments`: store in `absentCache` (5m TTL — short TTL so an `environments` update takes effect promptly), return `null`; if `status != active` (revoked): store in `revokedCache` (366d TTL), return `null`
 - [x] 4.8 Implement revocation eviction method `evictCredential(String jti)` — evict `jti` from `credentialCache` and `absentCache`, insert into `revokedCache` with 366d TTL
 
 ## 5. Authentication Enforcement Filter
@@ -58,11 +58,11 @@
 - [x] 9.2 Unit test — wrong algorithm (RS256 JWT) → returns `null`, no SM call
 - [x] 9.3 Unit test — wrong issuer → returns `null`, no SM call
 - [x] 9.4 Unit test — expired `exp` claim → returns `null`
-- [x] 9.5 Unit test — wrong `env` claim → returns `null`
+- [ ] 9.5 Unit test — request target environment not in credential's `environments` list → returns `null`
 - [x] 9.6 Unit test — REVOKED sentinel in credential cache → returns `null`, no DynamoDB call
 - [x] 9.7 Unit test — DynamoDB returns revoked status → returns `null`, inserts REVOKED sentinel
 - [x] 9.8 Unit test — `evictCredential` inserts REVOKED sentinel and subsequent lookup returns `null`
-- [x] 9.9 Unit test `ApiKeyCredentialRepository` — `findByEnvAndJti` constructs correct sort key and returns `Optional.empty()` on miss
+- [ ] 9.9 Unit test `ApiKeyCredentialRepository` — `findByJti` constructs sort key `{jti}` and returns `Optional.empty()` on miss
 - [x] 9.10 Verify `AuthenticationEnforcementFilter` returns 401 for `UnauthenticatedPrincipal` and passes through for authenticated principal
 
 ## 11. UPN Claim — Authorization Identity Fix

--- a/openspec/changes/igdd-2705-api-key-principal-provider/tasks.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/tasks.md
@@ -45,7 +45,15 @@
 
 ## 10. Bug Fix — AccessControlService Role Check
 
-- [x] 10.1 Fix `AccessControlService.isUserInRole()` to fall back to checking `ApiKeyPrincipal.getRoles()` when the DynamoDB access control table has no entry for the principal. Without this fix, API key callers always received 401 on protected endpoints because `AccessControlValve` identifies users by `principal.getName()` (the `upn` value), which has no entry in the cert-based access control table.
+> **SUPERSEDED — do not implement.** The `jwt-upn-authorization` change reversed this task:
+> the JWT-claim roles fallback was removed from `AccessControlService.isUserInRole()`, and
+> `ApiKeyPrincipal` no longer carries roles at all. Role assignments come solely from the
+> DynamoDB AccessGroup table, keyed on `principal.getName()` (the `upn` for JWT clients, the
+> CN for cert clients) — the same lookup used for mTLS callers. The 401 problem described
+> below is instead resolved by provisioning the credential's UPN into an AccessGroup.
+> Retained for history; see `openspec/changes/jwt-upn-authorization/`.
+
+- [x] ~~10.1 Fix `AccessControlService.isUserInRole()` to fall back to checking `ApiKeyPrincipal.getRoles()` when the DynamoDB access control table has no entry for the principal. Without this fix, API key callers always received 401 on protected endpoints because `AccessControlValve` identifies users by `principal.getName()` (the `upn` value), which has no entry in the cert-based access control table.~~
 
 ## 12. OCSP Revocation for Header Certificate Path (izgw-core)
 

--- a/openspec/changes/igdd-2705-api-key-principal-provider/test-tokens.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/test-tokens.md
@@ -23,7 +23,7 @@ This sets `server.ssl.client-auth=want`, `jwt.issuer=http://localhost:3000`, and
 | Issuer | `http://localhost:3000` |
 | Subject (jurisdictionId) | `"42"` (numeric string — matches legacy IZG jurisdiction ID scheme) |
 | JTI | `018f4e2a-5678-7abc-8def-000000000002` |
-| Environment | `5` (Development) |
+| Environments (server-side on the DynamoDB record — NOT a JWT claim) | `[5]` (Development) |
 | UPN | `test.example.gov` |
 | Roles | `ads`, `soap` |
 | Expires | 2038-01-19 (far future — dev only) |
@@ -37,9 +37,9 @@ Before using this token, create the matching `ApiKeyCredential` record in your l
 ```json
 {
   "entityType": "ApiKeyCredential",
-  "sortKey": "5#018f4e2a-5678-7abc-8def-000000000002",
+  "sortKey": "018f4e2a-5678-7abc-8def-000000000002",
   "jti": "018f4e2a-5678-7abc-8def-000000000002",
-  "env": "5",
+  "environments": [5],
   "status": "active",
   "jurisdictionId": "42",
   "issuedAt": "2025-06-04T00:00:00Z",
@@ -55,7 +55,7 @@ const jwt = require('jsonwebtoken');
 console.log(jwt.sign(
   { iss:'http://localhost:3000', sub:'42', jti:'018f4e2a-5678-7abc-8def-000000000002',
     iat:Math.floor(Date.now()/1000), exp:Math.floor(Date.now()/1000)+(365*24*3600),
-    upn:'test.example.gov', roles:['ads','soap'], env:5 },
+    upn:'test.example.gov', roles:['ads','soap'] },
   'izg-test-secret-igdd-2705-do-not-use-in-production',
   { algorithm:'HS256', header:{ kid:'00000000-0000-0000-0000-000000000001' } }
 ));
@@ -78,9 +78,7 @@ const token = jwt.sign(
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(Date.now() / 1000) + (365 * 24 * 3600),
     upn: 'test.example.gov',
-    env: 5,
-    roles: ['ads', 'soap'],
-    env: 5
+    roles: ['ads', 'soap']
   },
   'izg-test-secret-igdd-2705-do-not-use-in-production',
   { algorithm: 'HS256', header: { kid: '00000000-0000-0000-0000-000000000001' } }

--- a/openspec/changes/igdd-2705-api-key-principal-provider/test-tokens.md
+++ b/openspec/changes/igdd-2705-api-key-principal-provider/test-tokens.md
@@ -25,8 +25,16 @@ This sets `server.ssl.client-auth=want`, `jwt.issuer=http://localhost:3000`, and
 | JTI | `018f4e2a-5678-7abc-8def-000000000002` |
 | Environments (server-side on the DynamoDB record — NOT a JWT claim) | `[5]` (Development) |
 | UPN | `test.example.gov` |
-| Roles | `ads`, `soap` |
+| Roles | `ads`, `soap` — **inert, see note below** |
 | Expires | 2038-01-19 (far future — dev only) |
+
+> **The `roles` claim is ignored by the Hub.** The `jwt-upn-authorization` change removed
+> JWT-claim roles: `ApiKeyPrincipal` carries no roles, and `AccessControlValve` resolves
+> roles from the DynamoDB AccessGroup table keyed on `principal.getName()` (the `upn`).
+> The claim is left in the snippets below only because it is present in previously issued
+> tokens; new tokens need not include it. To exercise a protected endpoint, provision
+> `test.example.gov` into an AccessGroup carrying the roles you need (`soap` for the SOAP
+> endpoints; `users` plus an `ads`-prefixed group for ADS/DEX).
 
 **Token:** regenerate using the Node.js snippet below (`dns` claim replaced by `upn`; the previous token is no longer valid).
 

--- a/openspec/changes/igdd-2711-grace-period-revocation/design.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/design.md
@@ -6,7 +6,7 @@ IGDD-2705 already built the validation machinery this job reuses:
 - `ApiKeyPrincipalProvider.evictCredential(String jti)` — evicts a `jti` from the in-memory credential cache (forcing re-validation against DynamoDB).
 - The credential cache has a bounded TTL (`jwt.credential-cache-ttl`, default 5 minutes), so a status change in DynamoDB takes effect on every instance within that window even without an explicit eviction.
 
-The `ApiKeyCredential` record uses `entityType = "ApiKeyCredential"` with sort key `{env}#{jti}`; lookups are environment-scoped by prefix (Hub's `findByEnvAndJti` does `find(env + "#" + jti)`).
+The `ApiKeyCredential` record uses `entityType = "ApiKeyCredential"` with sort key `{jti}` (no environment prefix); Hub reads a credential directly by `jti` (`findByJti(jti)`).
 
 ## Goals / Non-Goals
 
@@ -31,13 +31,13 @@ The `ApiKeyCredential` record uses `entityType = "ApiKeyCredential"` with sort k
 Hub is a long-running Spring Boot service that already hosts scheduled work (`StatusCheckScheduler`) and already wires `ApiKeyCredentialRepository`, `ApiKeyPrincipalProvider`, and `ApiKeyAuditLogger`. An in-process job reuses all of it with no new deployable artifact, IAM role, or infra. The acceptance criteria's "Lambda timeout or ECS task failure" is read generically as "the scheduled job failed to run" and is satisfied by Hub-level monitoring (D7). Trade-off: the job's health is coupled to Hub's; mitigated by the single-runner guard and the failure alarm.
 
 ### D2 — Add `graceExpiresAt` + `supersededBy` to Hub's `ApiKeyCredential`
-The DynamoDB table is shared: Config Console writes these attributes, Hub reads them. Hub's `@DynamoDbBean` must declare them (`graceExpiresAt` serializes as an ISO-8601 string like `issuedAt`/`expiresAt`) or the sweep cannot see them. Both are nullable; records predating renewal have `null` and are never selected. Status literals are the lowercase set `active` / `revoked` / `expired` (see D8).
+The DynamoDB table is shared: Config Console writes these attributes, Hub reads them. Hub's `@DynamoDbBean` must declare them (`graceExpiresAt` serializes as an ISO-8601 string like `issuedAt`/`expiresAt`) or the sweep cannot see them. Both are nullable; records predating renewal have `null` and are never selected. Status literals are the lowercase set `active` / `grace_period` / `revoked` (see D8).
 
 ### D3 — Candidate selection: `status == grace_period && graceExpiresAt != null && graceExpiresAt <= now`
 On renewal Config Console moves the superseded (old) key to status `grace_period` with a non-null `graceExpiresAt` (per IGDD-2707); it keeps authenticating alongside the new key (auth accepts `active` **and** `grace_period` — see D8) until that instant passes. The sweep selects exactly the `grace_period` keys whose grace has elapsed and transitions them to `revoked`. Normal `active` keys have no `graceExpiresAt` and are never selected. `supersededBy` is not part of the selection predicate but is carried into the audit event for traceability. Already-`revoked` keys are skipped (idempotent: re-running the job revokes nothing new).
 
-### D4 — Query strategy: environment-scoped prefix query, GSI deferred
-The candidate finder uses the base repository's `findByType(env + "#")` (sort-key prefix query within the `ApiKeyCredential` entity type) then filters in memory on `status`/`graceExpiresAt`. At expected key volumes (one credential per jurisdiction-domain, low hundreds) this is adequate and avoids new index cost; a GSI on `status`+`graceExpiresAt` is the future escape hatch. The finder lives on `ApiKeyCredentialRepository` so the strategy is swappable without touching the scheduler.
+### D4 — Query strategy: entity-type scan, GSI deferred
+The candidate finder uses the base repository's `findByType("ApiKeyCredential")` (all credential records — the sort key is `{jti}` with no environment prefix to scope on) then filters in memory on `status`/`graceExpiresAt`. At expected key volumes (one credential per jurisdiction-domain, low hundreds) this is adequate and avoids new index cost; a GSI on `status`+`graceExpiresAt` is the future escape hatch. The finder lives on `ApiKeyCredentialRepository` so the strategy is swappable without touching the scheduler.
 
 ### D5 — Multi-instance safety via a conditional write (not a runner election) — revised 2026-07-20
 Hub runs multiple instances behind an ALB; every enabled instance runs the sweep each cycle. Correctness does not depend on electing a single runner — each candidate is revoked with a **conditional DynamoDB update** (`revokeIfGracePeriod`: `SET status=revoked … WHERE status = grace_period`). Only the first instance's write succeeds; the losers get a `ConditionalCheckFailedException` and skip the audit event, so each key is revoked **and audited exactly once** across the fleet, with no dependency on host coordination.
@@ -52,12 +52,12 @@ It does **not** broadcast the eviction to other instances. The acceptance criter
 ### D7 — Failure detection and runbook (AC #3)
 Each run logs a structured completion record with counts; failures are logged at ERROR. A CloudWatch log-based alarm fires when either (a) an error is logged by the job, or (b) no successful-completion record is seen within an expected window (missed run). The operations runbook documents the manual remediation: confirm Hub health, and if needed run the manual revoke through Config Console (`DELETE /api/apikeys/:jti`) for any key whose `graceExpiresAt` has passed.
 
-### D8 — Status model: lowercase `active` / `grace_period` / `revoked` / `expired` (updated 2026-07-01)
+### D8 — Status model: lowercase `active` / `grace_period` / `revoked` (updated 2026-07-01)
 Status literals are lowercase (per Keith's IGDD-2703 ADR). The model gained a distinct **`grace_period`** status for a renewed key during its grace window (IGDD-2705 commit `82750a99c` "Adding support for 'grace_period' status in addition to 'active'"). This supersedes the earlier "no grace status; key stays active" position. Consequences:
 - **Auth (IGDD-2705)** treats a credential as usable when `status` is `active` **or** `grace_period` (`ApiKeyPrincipalProvider.isUsableStatus`), so a renewed old key keeps authenticating during grace.
 - **This job (2711)** selects `grace_period` keys past `graceExpiresAt` (D3) and transitions them to `revoked`.
 - **Config Console (IGDD-2707)** must write `status = "grace_period"` on the old key at renewal. Its current branch still writes `"superseded"` (a value nothing recognizes) — that is a remaining CC fix; the target is `grace_period`, not `active` and not `superseded`.
-- Environment is a numeric string (e.g. `"5"`), used both in the JWT `env` claim and the `{env}#{jti}` sort key (IGDD-2705 commit `0287b796e`).
+- Environment is NOT a JWT claim and is NOT part of the sort key. A credential's permitted environments are a server-side `environments` list (numeric IDs) on the record; the sort key is `{jti}` alone (IGDD-2705, D7).
 
 ## Risks / Trade-offs
 
@@ -70,11 +70,11 @@ Status literals are lowercase (per Keith's IGDD-2703 ADR). The model gained a di
 ## Open Questions
 
 - **Q1 — RESOLVED (team, 2026-06-24/25, grounded in the IGDD-2703 ADR).** The contract is settled enough to implement:
-  1. Status literals: lowercase **`active` / `revoked`** (`expired` also valid); **no `'Grace Period'` status** (D8). Hub's 2705 auth needs no change; Config Console conforms to lowercase in storage and drops `'Grace Period'`.
+  1. Status literals: lowercase **`active` / `grace_period` / `revoked`** (D8). Config Console conforms to lowercase in storage and writes `grace_period` (not `superseded`) on the renewed old key.
   2. CC adds **`graceExpiresAt`** (absolute ISO-8601 timestamp, set on the old key at renewal) and **`supersededBy`** (new jti). Hub adds both to `ApiKeyCredential` and reads them.
-  3. Grace key = `active` + non-null `graceExpiresAt`. Job selects `status == active && graceExpiresAt != null && graceExpiresAt <= now` → `revoked`.
-  4. Sort key `{env}#{jti}` with `entityType = "ApiKeyCredential"` — confirmed by Paul against the dev table; matches Hub's existing `findByEnvAndJti`, no change.
+  3. Grace key = `grace_period` + non-null `graceExpiresAt`. Job selects `status == grace_period && graceExpiresAt != null && graceExpiresAt <= now` → `revoked`.
+  4. Sort key `{jti}` with `entityType = "ApiKeyCredential"`; Hub reads the record directly by `jti` (`findByJti`).
 
   *Caveat:* CC's renewal write-path is not yet built, so end-to-end verification waits on IGDD-2707; Hub-side work proceeds against this agreed contract.
-- **Q2** — Single-runner mechanism: reuse `StatusCheckScheduler`'s host-ordering vs. a dedicated conditional-write lock item. Decide during implementation based on how strict the "exactly once per cycle" requirement is.
+- **Q2 — RESOLVED (2026-07-20, see D5).** Settled in favor of the conditional DynamoDB write (`revokeIfGracePeriod`) over any single-runner election: every enabled instance runs each cycle and the conditional write makes each key revoke+audit exactly once. The earlier host-ordering election was removed (stale-host registry made a lone instance defer to a ghost and never run).
 - **Q3** — Run interval default (e.g. hourly) and whether it should be environment-configurable.

--- a/openspec/changes/igdd-2711-grace-period-revocation/proposal.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-When a jurisdiction renews an API key, Config Console (IGDD-2707) issues a new credential but leaves the old one **active** for a configurable grace period — it stamps the old `ApiKeyCredential` with `supersededBy = <new jti>` and `graceExpiresAt`, so both keys authenticate while the caller cuts over. Nothing currently revokes the old key once that grace window closes. Without an automated sweep, superseded keys accumulate as indefinitely-valid credentials, defeating the purpose of renewal and widening the credential attack surface.
+When a jurisdiction renews an API key, Config Console (IGDD-2707) issues a new credential but leaves the old one usable (status **`grace_period`**) for a configurable grace period — it stamps the old `ApiKeyCredential` with `status = grace_period`, `supersededBy = <new jti>`, and `graceExpiresAt`, so both keys authenticate while the caller cuts over. Nothing currently revokes the old key once that grace window closes. Without an automated sweep, superseded keys accumulate as indefinitely-valid credentials, defeating the purpose of renewal and widening the credential attack surface.
 
 This change adds a scheduled job inside Hub that revokes superseded API keys after their grace period expires (IGDD-2711, User Story 10).
 
@@ -25,7 +25,7 @@ This change adds a scheduled job inside Hub that revokes superseded API keys aft
 ## Impact
 
 - **DynamoDB shared table** — `ApiKeyCredential` gains two attributes written by Config Console (IGDD-2707) and read by Hub. No table/key structure change; new optional attributes only. Older records without these attributes deserialize with `null` and are never selected by the sweep.
-- **Status literals** — lowercase `active` / `revoked` per Keith's IGDD-2703 ADR (no `'Grace Period'` status; grace is a timestamp on an `active` key). Hub's 2705 auth path already matches; Config Console conforms in storage and capitalizes only for display.
+- **Status literals** — lowercase `active` / `grace_period` / `revoked` per Keith's IGDD-2703 ADR. Hub's 2705 auth path treats `active` and `grace_period` as usable; Config Console conforms in storage and capitalizes only for display.
 - **Cache coherence** — the acting instance evicts the revoked key from its cache immediately; other instances converge within the credential-cache TTL (default 5 min) as entries expire and re-validate against DynamoDB. Immediate fleet-wide broadcast is intentionally out of scope (design D6) — it is the manual-revoke path's concern (IGDD-2707).
 - **Scheduling** — Hub gains an `@EnableScheduling`-driven job. Hub runs multi-instance behind an ALB, so the job needs a single-runner guard to avoid redundant writes/audit noise.
 - **Observability / Ops** — per-run counts logged for CloudWatch; a log-based CloudWatch alarm plus an operations runbook entry cover the "job failed to run" acceptance criterion (AC #3).

--- a/openspec/changes/igdd-2711-grace-period-revocation/runbook.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/runbook.md
@@ -16,9 +16,11 @@ period expires. Satisfies IGDD-2711 AC #3 (failure detection + manual remediatio
 
 `GracePeriodRevocationScheduler` runs inside Hub on a fixed interval
 (`apikey.grace-revocation.interval`, default 1h; gated by `apikey.grace-revocation.enabled`). Each
-cycle it finds credentials that are `active` with a `graceExpiresAt` in the past, sets them to
+cycle it finds credentials that are `grace_period` with a `graceExpiresAt` in the past, sets them to
 `revoked` in DynamoDB, emits an `API_KEY_REVOKED` audit event, and evicts the key from the local
-credential cache. A single instance runs per cycle (host-ordering election). Revocation is idempotent.
+credential cache. Every enabled instance runs each cycle; a conditional DynamoDB write
+(`revokeIfGracePeriod`, which revokes only while `status = grace_period`) ensures each key is revoked
+and audited exactly once across the fleet. Revocation is idempotent.
 
 ## Log signals
 
@@ -55,15 +57,15 @@ grace period:
    cause a missed run. Restarting/restoring Hub lets the next scheduled cycle catch up automatically
    (the job is idempotent and processes all expired-grace keys each run).
 2. **If Hub cannot be restored promptly, revoke manually via Config Console** — for each affected key
-   (status `active` with `graceExpiresAt` in the past), call:
+   (status `grace_period` with `graceExpiresAt` in the past), call:
    ```
    DELETE /api/apikeys/{jti}
    ```
    Config Console sets the credential to `revoked` and propagates cache eviction to all Hub instances
    via `/rest/refresh`. This is the same end state the job would have produced.
-3. **Identify affected keys** — query the `ApiKeyCredential` records for the environment where
-   `status = active` and `graceExpiresAt < now` (e.g. via the Config Console key list or a DynamoDB
-   query on `entityType = ApiKeyCredential`, sort key prefix `{env}#`).
+3. **Identify affected keys** — query the `ApiKeyCredential` records where
+   `status = grace_period` and `graceExpiresAt < now` (e.g. via the Config Console key list or a DynamoDB
+   query on `entityType = ApiKeyCredential`).
 4. **Verify** — confirm the keys now show `revoked` and that an `API_KEY_REVOKED` audit event was
    recorded for each.
 

--- a/openspec/changes/igdd-2711-grace-period-revocation/specs/api-key-credential/spec.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/specs/api-key-credential/spec.md
@@ -1,12 +1,12 @@
 ## MODIFIED Requirements
 
 ### Requirement: ApiKeyCredential entity structure
-`ApiKeyCredential` SHALL be a DynamoDB entity following Hub's single-table design. It SHALL extend `DynamoDbAudit` and be annotated with `@DynamoDbBean`. Its sort key SHALL be `ApiKeyCredential#{env}#{jti}`, where `env` is the environment name and `jti` is the UUID token identifier.
+`ApiKeyCredential` SHALL be a DynamoDB entity following Hub's single-table design. It SHALL extend `DynamoDbAudit` and be annotated with `@DynamoDbBean`. Its sort key SHALL be `{jti}` — the credential's UUID token identifier alone, with no environment prefix.
 
 Required fields:
 - `jti` — String; the JWT `jti` claim; unique credential identifier
-- `env` — String; the environment name (e.g., `Production`, `Onboarding`)
-- `status` — String; one of `active`, `grace_period`, `revoked`, `expired` (a renewed key sits in `grace_period` during its grace window and still authenticates)
+- `environments` — List of numeric environment IDs (`number[]`); the environments in which the credential is valid. Read by Hub at routing time — NOT carried in the JWT.
+- `status` — String; one of `active`, `grace_period`, `revoked` (a renewed key sits in `grace_period` during its grace window and still authenticates)
 - `jurisdictionId` — String; the jurisdiction the credential was issued to (from JWT `sub`)
 - `issuedAt` — `Instant`; when the credential was issued (serialized via `InstantAsStringAttributeConverter`)
 - `expiresAt` — `Instant`; when the credential expires (serialized via `InstantAsStringAttributeConverter`)
@@ -18,8 +18,8 @@ Required fields:
 `graceExpiresAt` and `supersededBy` are written by Config Console's renewal route and read by Hub; records that predate renewal have `null` for both and SHALL deserialize without error.
 
 #### Scenario: Entity persisted by Config Console is readable by Hub
-- **WHEN** Config Console writes an `ApiKeyCredential` record with `status = active` using sort key `ApiKeyCredential#Production#<jti>`
-- **THEN** Hub's repository can read that record by `env = Production` and `jti = <jti>` and deserialize it without error
+- **WHEN** Config Console writes an `ApiKeyCredential` record with `status = active` using sort key `<jti>`
+- **THEN** Hub's repository can read that record by `jti = <jti>` and deserialize it without error
 
 #### Scenario: Superseded credential carries grace fields
 - **WHEN** Config Console renews a credential and writes the old record with `status = grace_period`, `supersededBy = <new-jti>`, and `graceExpiresAt = 2026-07-01T00:00:00Z`
@@ -32,10 +32,10 @@ Required fields:
 ## ADDED Requirements
 
 ### Requirement: ApiKeyCredentialRepository finder for grace-revocation candidates
-`ApiKeyCredentialRepository` SHALL provide a method that returns the `ApiKeyCredential` records eligible for automated grace-period revocation in the current environment: those with `status == grace_period`, a non-null `graceExpiresAt`, and `graceExpiresAt <= now`. The query SHALL be scoped to the current environment (the `{env}#` sort-key prefix). Records with a `null` `graceExpiresAt`, or whose `graceExpiresAt` is in the future, or whose `status` is not `grace_period` (e.g. a normal `active` key), SHALL NOT be returned.
+`ApiKeyCredentialRepository` SHALL provide a method that returns the `ApiKeyCredential` records eligible for automated grace-period revocation: those with `status == grace_period`, a non-null `graceExpiresAt`, and `graceExpiresAt <= now`. Because the sort key is `{jti}` with no environment prefix, the query SHALL scan all `ApiKeyCredential` records (by `entityType`) and filter in memory on `status`/`graceExpiresAt`. Records with a `null` `graceExpiresAt`, or whose `graceExpiresAt` is in the future, or whose `status` is not `grace_period` (e.g. a normal `active` key), SHALL NOT be returned.
 
 #### Scenario: Expired-grace superseded key is selected
-- **WHEN** the finder runs and a record exists with `status = grace_period`, `graceExpiresAt = <one hour ago>`, in the current environment
+- **WHEN** the finder runs and a record exists with `status = grace_period`, `graceExpiresAt = <one hour ago>`
 - **THEN** that record is included in the returned candidates
 
 #### Scenario: Grace not yet expired is excluded

--- a/openspec/changes/igdd-2711-grace-period-revocation/specs/grace-period-revocation/spec.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/specs/grace-period-revocation/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Scheduled grace-period revocation sweep
-Hub SHALL run a scheduled, in-process job that periodically revokes superseded API-key credentials whose grace period has expired. On each cycle the job SHALL query for candidates (`status == grace_period`, non-null `graceExpiresAt`, `graceExpiresAt <= now`, current environment) and, for each candidate, transition it to `revoked`.
+Hub SHALL run a scheduled, in-process job that periodically revokes superseded API-key credentials whose grace period has expired. On each cycle the job SHALL query for candidates (`status == grace_period`, non-null `graceExpiresAt`, `graceExpiresAt <= now`) across all `ApiKeyCredential` records and, for each candidate, transition it to `revoked`.
 
 The run interval SHALL be configurable (`apikey.grace-revocation.*`), and the job SHALL be guarded so that, in a multi-instance Hub deployment, a single instance performs revocation per cycle.
 

--- a/openspec/changes/igdd-2711-grace-period-revocation/tasks.md
+++ b/openspec/changes/igdd-2711-grace-period-revocation/tasks.md
@@ -1,13 +1,13 @@
 ## 0. Upstream contract (IGDD-2707) — RESOLVED
 
 - [x] 0.1 Confirm grace-field names/semantics — `graceExpiresAt` (absolute ISO-8601 `Instant`, set on the old key at renewal) and `supersededBy` (`String` jti). Confirmed with the team (2026-06-24/25).
-- [x] 0.2 Confirm a superseded key keeps `status = "active"` (lowercase) during the grace window; no distinct `'Grace Period'` status (Keith's IGDD-2703 ADR). Hub uses lowercase literals.
+- [x] 0.2 Confirm a superseded key carries `status = "grace_period"` (lowercase) during the grace window — a distinct grace status per D8 / IGDD-2705 commit `82750a99c` (supersedes the earlier "stays `active`, no grace status" position). Hub uses lowercase literals.
 
 ## 1. Entity and Repository
 
 - [x] 1.1 Add `graceExpiresAt` (`Instant`, nullable) and `supersededBy` (`String`, nullable) to `ApiKeyCredential` (serialized as ISO-8601 like `issuedAt`/`expiresAt`).
-- [x] 1.2 Add `findGraceRevocationCandidates(env)` to `ApiKeyCredentialRepository` — env-prefixed `findByType(env + "#")` (env = numeric string via `String.valueOf(SystemUtils.getDestType())`) + in-memory filter `status == "grace_period" && graceExpiresAt != null && graceExpiresAt <= now`.
-- [x] 1.3 Derive the environment prefix as the **numeric** string `String.valueOf(SystemUtils.getDestType())` (e.g. `"5"`) — matching how `ApiKeyPrincipalProvider` builds `env` (`String.valueOf(envInt)`) and how records are sort-keyed. (`getDestTypeAsString()` returns the human-readable name and would match nothing.)
+- [ ] 1.2 Add `findGraceRevocationCandidates()` to `ApiKeyCredentialRepository` — scan all credential records via `findByType("ApiKeyCredential")` (the sort key is `{jti}`, so there is no environment prefix to scope on) + in-memory filter `status == "grace_period" && graceExpiresAt != null && graceExpiresAt <= now`.
+- [ ] 1.3 Remove the old environment-prefix derivation (`String.valueOf(SystemUtils.getDestType())`) — the `ApiKeyCredential` sort key is `{jti}` alone and a credential's permitted environments are a server-side `environments` list, so the sweep is environment-agnostic and evaluates every credential record.
 
 ## 2. Audit event
 
@@ -37,7 +37,7 @@
 
 ## 6. Tests
 
-- [x] 6.1 Repository logic — `selectGraceCandidates` (6 cases: past/now/future/null grace, non-grace, mixed) + `buildGraceRevokeRequest` (asserts the conditional UpdateItem: key `{env}#{jti}`, condition `status = grace_period`, revoked/timestamp/actor values) unit-tested in `ApiKeyCredentialRepositoryTests`. The DynamoDB calls (`findByType`, `updateItem`) are thin delegations covered by integration/dev testing.
+- [ ] 6.1 Repository logic — `selectGraceCandidates` (6 cases: past/now/future/null grace, non-grace, mixed) + `buildGraceRevokeRequest` (asserts the conditional UpdateItem: key `{jti}`, condition `status = grace_period`, revoked/timestamp/actor values) unit-tested in `ApiKeyCredentialRepositoryTests`. The DynamoDB calls (`findByType`, `updateItem`) are thin delegations covered by integration/dev testing.
 - [ ] 6.2 Entity round-trip — `graceExpiresAt`/`supersededBy` serialize/deserialize without precision loss; legacy null record. **Deferred to integration** — genuinely needs a real DynamoDB table (no DynamoDB Local/Testcontainers harness in this repo); will be covered by the IGDD-2707 end-to-end validation.
 - [x] 6.3 Scheduler — winning conditional write → audit emitted with `supersededBy` + local cache evicted (`wonConditionalWrite_isAuditedAndEvicted`); losing write (another instance won) → no audit/evict (`lostConditionalWrite_noAuditNoEvict`); mixed batch audits only the winners.
 - [x] 6.5 Scheduler — idempotent skip of already-revoked. (`nonActiveCandidate_isSkipped`, `multipleCandidates_revokesOnlyActiveOnes`)
@@ -50,6 +50,6 @@
 ## Remaining before merge
 
 - **6.2 entity round-trip** integration test — needs a real DynamoDB table; folds into the IGDD-2707 end-to-end validation.
-- **End-to-end** verification waits on IGDD-2707's renewal write-path landing on `origin` with the agreed contract — as of 2026-07-01 that branch still writes `status='superseded'` (should be left `active`) and persists `supersededByJti` (Hub reads `supersededBy`). Once fixed + merged, re-verify and adjust only if the contract changed.
+- **End-to-end** verification waits on IGDD-2707's renewal write-path landing on `origin` with the agreed contract — as of 2026-07-01 that branch still writes `status='superseded'` (should be `grace_period`) and persists `supersededByJti` (Hub reads `supersededBy`). Once fixed + merged, re-verify and adjust only if the contract changed.
 
 Alerting is intentionally out of scope for now (Paul, 2026-07-01): the job emits started/succeeded/failed log messages; automated CloudWatch alarms are deferred to APHL as future work (spec in `runbook.md`). All Hub-side code, logging, and unit-testable logic for IGDD-2711 is complete.

--- a/openspec/changes/jwt-upn-authorization/specs/api-key-principal-provider/spec.md
+++ b/openspec/changes/jwt-upn-authorization/specs/api-key-principal-provider/spec.md
@@ -2,8 +2,8 @@
 
 ### Requirement: DynamoDB credential status check
 When the credential cache misses, Hub SHALL read the `ApiKeyCredential` record and act on its `status`:
-- **active** or **grace_period**: construct an `ApiKeyPrincipal` from JWT claims (`upn` → `name` (IzgPrincipal.getName()), `sub` → `organization` (a numeric string jurisdiction ID, e.g., `"42"`), `jti` → jti), store in credential cache with `jwt.credential-cache-ttl` (default 5 minutes), and return the principal. The `roles` field on the returned principal SHALL be empty; JWT claims SHALL NOT be used to populate roles.
-- **revoked**, **expired**, or record absent: store a REVOKED sentinel in credential cache with TTL equal to the maximum possible token lifetime (1 year), and return `null`.
+- **active** or **grace_period**: validate that the request's target environment (`SystemUtils.getDestType()`) is contained in the credential's server-side `environments` list (see IGDD-2705); if it is not, return `null`. Otherwise construct an `ApiKeyPrincipal` from JWT claims (`upn` → `name` (IzgPrincipal.getName()), `sub` → `organization` (a numeric string jurisdiction ID, e.g., `"42"`), `jti` → jti), store in credential cache with `jwt.credential-cache-ttl` (default 5 minutes), and return the principal. The `roles` field on the returned principal SHALL be empty; JWT claims SHALL NOT be used to populate roles.
+- **revoked** or record absent: store a REVOKED sentinel in credential cache with TTL equal to the maximum possible token lifetime (1 year), and return `null`.
 
 #### Scenario: Active credential
 - **WHEN** DynamoDB returns `status = active` for the `jti`
@@ -14,7 +14,7 @@ When the credential cache misses, Hub SHALL read the `ApiKeyCredential` record a
 - **THEN** a REVOKED sentinel is cached with max-token-lifetime TTL and `null` is returned, resulting in 401
 
 #### Scenario: Absent credential record
-- **WHEN** DynamoDB has no `ApiKeyCredential` record for `env#jti`
+- **WHEN** DynamoDB has no `ApiKeyCredential` record for `{jti}`
 - **THEN** the `jti` is cached in the absent cache (5-minute TTL) and `null` is returned
 
 ## ADDED Requirements


### PR DESCRIPTION
 ## OpenSpec alignment to IGDD-3140 — Hub adopts the `{jti}` / server-side-`environments` model

  Reconciled the three API-key changes (`igdd-2705-api-key-principal-provider`,
  `igdd-2711-grace-period-revocation`, `jwt-upn-authorization`) with the canonical IGDD-3140
  `ApiKeyCredential` contract. This is a **model change**, so it implies code rework (see
  re-opened tasks).

  - **Sort key `{env}#{jti}` → `{jti}`** (no env prefix) across specs, design, tasks, proposal, and `test-tokens.md`.
  - **Removed the numeric `env` JWT claim.** Environment authorization is now a server-side `environments` list on the record; at routing time the Hub looks the credential up by `jti` and checks its own env (`SystemUtils.getDestType()`) is in that list.
  - **`findByEnvAndJti` → `findByJti`.**
  - **Grace-revocation sweep scans all `ApiKeyCredential` records** by entityType (the env-prefix query no longer applies); resolved the `grace_period`-vs-`active` candidate predicate drift in favor of `grace_period`.
  - **Removed stored `expired`** (`active` / `grace_period` / `revoked`); `expired` is derived-only on the console side.
  - Reconciled the env enum to IGDD-3140 names (added `6 UNKNOWN`); cleaned the runbook's stale "host-ordering election" text; marked stale design Q2 RESOLVED.

  **Re-opened tasks (code now differs from the shipped `{env}#{jti}` + `env`-claim build):**
  2705 — `1.1, 1.2, 4.5, 4.6, 4.7, 9.5, 9.9`; 2711 — `1.2, 1.3, 6.1`.

  ⚠️ **Reviewer notes:**
  - `iss` + `kid` were already required by the Hub verifier and are unchanged — IGDD-3140 was updated to match the Hub here.
  - **New design detail:** an "env not in `environments`" result is cached under the short 5-min absent TTL (not the 366-day revoked sentinel) so an `environments` edit takes effect promptly. Flagging as it wasn't specified by IGDD-3140.