### PR TITLE
IGDD-3167: Distinguish Expired vs Revoked in grace-period sweeper

### DIFF
--- a/openspec/changes/igdd-3167-grace-sweeper-expired-status/design.md
+++ b/openspec/changes/igdd-3167-grace-sweeper-expired-status/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`GracePeriodRevocationScheduler` (IGDD-2711) already selects `grace_period` credentials whose
+`graceExpiresAt <= now` and transitions every one of them to `revoked` via a conditional DynamoDB
+write (exactly-once across instances). IGDD-3167 asks for the terminal status to distinguish
+*expired* (the key reached its own `expiresAt`) from *revoked* (the grace window closed before the
+key's own expiry). See `GracePeriodRevocationScheduler.java`, `ApiKeyCredentialRepository.java`,
+and the IGDD-2711 design doc (D3, D5, D8) for the existing mechanics this change builds on.
+
+## Decisions
+
+### D1 — Selection predicate is unchanged; only the terminal label changes
+
+The AC's precondition is "a `grace_period` credential whose effective grace end has passed," and
+defines effective grace end as `min(graceExpiresAt, expiresAt)`. The current finder
+(`selectGraceCandidates`) triggers only on `graceExpiresAt <= now`. These two conditions differ
+exactly when `expiresAt <= now < graceExpiresAt` — a key that reached its own expiry early but is
+still nominally inside its grace window.
+
+**Decision: leave the finder untouched.** The AC says *when the sweeper processes* such a
+credential, set the status thus — it does not require processing every credential whose `expiresAt`
+alone has passed while `graceExpiresAt` is still in the future. The ticket's Background frames the
+gap as "never writes expired and never compares `expiresAt` to `graceExpiresAt`" — a mislabeling
+gap on credentials already being processed, not a timeliness gap in *which* credentials are swept.
+Every credential the sweep does process gets the correct label under this change.
+
+Sweeping early on `expiresAt` alone would be a legitimate follow-on (timelier `expired` labeling for
+a key still nominally in grace), but it enlarges scope (new finder predicate, `expiresAt`-null
+handling, additional finder tests) beyond what this AC requires, and JWT `exp` already blocks the
+key from authenticating during that window regardless of persisted status. Not pursued here.
+
+### D2 — Add `expiredAt`/`expiredBy`; do not reuse `revokedAt`/`revokedBy` for expired outcomes
+
+`expiresAt` and `graceExpiresAt` already exist on `ApiKeyCredential` — they are *inputs* to the
+label decision (set once, at issuance / at renewal, never touched by this job), not outputs of it.
+There was no field recording *when the sweep flipped a credential's status*, for either outcome —
+that's what `revokedAt`/`revokedBy` already did for `revoked`, so `expired` needs the equivalent.
+
+Rejected: writing `revokedBy = system:grace-revocation` on a credential labeled `expired` — this
+directly contradicts the ticket's goal (the audit trail should reflect *why* the key stopped being
+usable) and would leave a `revokedAt` timestamp on a record that was never revoked.
+
+Chosen: mirror the existing pair exactly — `expiredAt` (`Instant`, nullable) and `expiredBy`
+(`String`, nullable) — written only on the `expired` branch, leaving `revokedAt`/`revokedBy` null
+for those records (and vice versa). A new `SYSTEM_GRACE_EXPIRATION` actor constant
+(`system:grace-expiration`) is used for `expiredBy` so the actor string itself doesn't say
+"revocation" for a credential that merely expired; `SYSTEM_GRACE_REVOCATION` is unchanged for the
+`revoked` branch.
+
+### D3 — Exactly-once semantics preserved
+
+The conditional write's condition expression (`status = grace_period`) is unchanged — only the
+terminal status *value* and which timestamp/actor attributes are set are parameterized by
+`resolveTerminalStatus`. The scheduler computes the label itself (via the same pure
+`resolveTerminalStatus`) before calling the repository, so it knows which audit event to emit on a
+won write without a re-read; the repository independently resolves the same label to pick the
+correct attributes to write. Both calls are pure functions of the same credential snapshot, so they
+always agree.

--- a/openspec/changes/igdd-3167-grace-sweeper-expired-status/proposal.md
+++ b/openspec/changes/igdd-3167-grace-sweeper-expired-status/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+`GracePeriodRevocationScheduler` (IGDD-2711) transitions every grace-expired credential to
+`revoked`, regardless of why the grace window ended. It never writes `expired` and never compares
+the credential's own `expiresAt` to `graceExpiresAt`. Per the credential state model the two
+outcomes are distinct: the JWT `exp` caps validity, so the *effective* grace end is
+`min(graceExpiresAt, expiresAt)`. A key that simply lived out its own lifetime should be recorded
+as `expired`; only a key cut off *before* its own expiry (grace window closed first) should be
+recorded as `revoked`. Today every aged-out key is mislabeled `revoked`, so the persisted status and
+the audit trail cannot answer "did this key expire naturally, or was it cut off early?" — a
+question IZ Gateway operators need answered when reviewing credential history.
+
+This is a status-accuracy/audit change only. Enforcement is unaffected: both `expired` and
+`revoked` are non-usable statuses, and the JWT `exp` already blocks time-expiry at request time
+independent of this job.
+
+## What Changes
+
+- **Modified**: `ApiKeyCredential` entity — add `expiredAt` (`Instant`, nullable) and `expiredBy`
+  (`String`, nullable), parallel to the existing `revokedAt`/`revokedBy`, so an `expired` transition
+  has its own terminal timestamp/actor instead of leaving `revokedAt`/`revokedBy` populated (which
+  would misrepresent the outcome as a revocation).
+- **Modified**: `ApiKeyCredentialRepository` — add `resolveTerminalStatus(credential)`, a pure
+  function that compares `expiresAt` to `graceExpiresAt` (`expiresAt <= graceExpiresAt` → `expired`,
+  else `revoked`). Replace `revokeIfGracePeriod`/`buildGraceRevokeRequest` with
+  `terminateIfGracePeriod`/`buildGraceTerminationRequest`, which write `status` plus either
+  `expiredAt`/`expiredBy` or `revokedAt`/`revokedBy` depending on the resolved status, still gated
+  by the same conditional write (`status = grace_period`) that gives exactly-once semantics across
+  instances.
+- **Modified**: `ApiKeyAuditLogger` — add an `API_KEY_EXPIRED` audit event
+  (`apiKeyExpired(keyId, jurisdictionId, expiredBy, supersededBy)`) and a
+  `SYSTEM_GRACE_EXPIRATION` actor constant, parallel to the existing `API_KEY_REVOKED` /
+  `SYSTEM_GRACE_REVOCATION`.
+- **Modified**: `GracePeriodRevocationScheduler` — compute the terminal status per candidate before
+  writing (via `resolveTerminalStatus`), pass the matching actor into the repository write, and emit
+  `apiKeyExpired` or `apiKeyRevoked` accordingly. Per-run logging splits the `revoked` count into
+  `expired`/`revoked` counts for operational visibility.
+
+Candidate *selection* (`findGraceRevocationCandidates` / `selectGraceCandidates`) is unchanged: the
+sweep still triggers on `graceExpiresAt <= now`, per the existing AC precondition ("when the
+sweeper processes a grace_period credential whose effective grace end has passed"). This change
+only affects the terminal status assigned once a credential is being processed.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `api-key-credential`: `ApiKeyCredential` gains `expiredAt`/`expiredBy`.
+- `grace-period-revocation`: the sweep now sets `expired` or `revoked` based on comparing
+  `expiresAt` to `graceExpiresAt`, and emits the matching audit event.
+
+## Impact
+
+- **DynamoDB shared table** — two new optional attributes on `ApiKeyCredential`, written only by
+  this job. No key-structure change; legacy records without them deserialize with `null`.
+- **Audit trail** — a new `API_KEY_EXPIRED` event type alongside the existing `API_KEY_REVOKED`;
+  consumers of the audit log (if any) that assumed every grace-sweep outcome was `API_KEY_REVOKED`
+  will now also see `API_KEY_EXPIRED`.
+- **Monitoring** — `GRACE_REVOCATION_RUN`'s `revoked` count field now reflects only true revocations
+  (an `expired` field is added alongside it). The event type itself, and the "missed run" / "job
+  failure" alarm design in the IGDD-2711 runbook (keyed on event presence, not count values), are
+  unaffected.
+- **No enforcement change** — `expired` and `revoked` remain equally non-usable; JWT `exp` already
+  blocks time-expired tokens at request time regardless of persisted status.

--- a/openspec/changes/igdd-3167-grace-sweeper-expired-status/specs/api-key-credential/spec.md
+++ b/openspec/changes/igdd-3167-grace-sweeper-expired-status/specs/api-key-credential/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: ApiKeyCredential entity structure
+`ApiKeyCredential` SHALL be a DynamoDB entity following Hub's single-table design. It SHALL extend `DynamoDbAudit` and be annotated with `@DynamoDbBean`. Its sort key SHALL be `ApiKeyCredential#{env}#{jti}`, where `env` is the environment name and `jti` is the UUID token identifier.
+
+Required fields:
+- `jti` — String; the JWT `jti` claim; unique credential identifier
+- `env` — String; the environment name (e.g., `Production`, `Onboarding`)
+- `status` — String; one of `active`, `grace_period`, `revoked`, `expired` (a renewed key sits in `grace_period` during its grace window and still authenticates)
+- `jurisdictionId` — String; the jurisdiction the credential was issued to (from JWT `sub`)
+- `issuedAt` — `Instant`; when the credential was issued (serialized via `InstantAsStringAttributeConverter`)
+- `expiresAt` — `Instant`; when the credential expires (serialized via `InstantAsStringAttributeConverter`)
+- `revokedAt` — `Instant` (nullable); when the credential was revoked (set only when `status` transitions to `revoked`)
+- `revokedBy` — String (nullable); identity of the revoking operator (e.g. an operator id for a manual revoke, or `system:grace-revocation` for an automated grace-period revocation)
+- `expiredAt` — `Instant` (nullable); when the credential was marked expired (set only when `status` transitions to `expired`, e.g. `system:grace-expiration` for the automated grace-period sweep)
+- `expiredBy` — String (nullable); identity/process that recorded the expiry
+- `graceExpiresAt` — `Instant` (nullable); set by Config Console at renewal on the superseded (old) credential; the instant after which a superseded credential becomes eligible for automated revocation. Serialized via `InstantAsStringAttributeConverter`.
+- `supersededBy` — String (nullable); set by Config Console at renewal on the old credential; the `jti` of the renewed credential that replaced it.
+
+`graceExpiresAt` and `supersededBy` are written by Config Console's renewal route and read by Hub; records that predate renewal have `null` for both and SHALL deserialize without error. `expiredAt`/`expiredBy` are written only by Hub's grace-period sweep (IGDD-3167); a credential SHALL NOT have both `revokedAt` and `expiredAt` populated.
+
+#### Scenario: Entity persisted by Config Console is readable by Hub
+- **WHEN** Config Console writes an `ApiKeyCredential` record with `status = active` using sort key `ApiKeyCredential#Production#<jti>`
+- **THEN** Hub's repository can read that record by `env = Production` and `jti = <jti>` and deserialize it without error
+
+#### Scenario: Superseded credential carries grace fields
+- **WHEN** Config Console renews a credential and writes the old record with `status = grace_period`, `supersededBy = <new-jti>`, and `graceExpiresAt = 2026-07-01T00:00:00Z`
+- **THEN** Hub's repository reads the record back with `graceExpiresAt` equal to `2026-07-01T00:00:00Z` and `supersededBy` equal to `<new-jti>` (no precision loss, no null)
+
+#### Scenario: Legacy record without grace fields
+- **WHEN** Hub reads an `ApiKeyCredential` that was written before grace fields existed
+- **THEN** `graceExpiresAt` and `supersededBy` are `null` and the record deserializes without error
+
+#### Scenario: Legacy record without expired fields
+- **WHEN** Hub reads an `ApiKeyCredential` that was written before `expiredAt`/`expiredBy` existed
+- **THEN** `expiredAt` and `expiredBy` are `null` and the record deserializes without error

--- a/openspec/changes/igdd-3167-grace-sweeper-expired-status/specs/grace-period-revocation/spec.md
+++ b/openspec/changes/igdd-3167-grace-sweeper-expired-status/specs/grace-period-revocation/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Scheduled grace-period revocation sweep
+Hub SHALL run a scheduled, in-process job that periodically terminates superseded API-key credentials whose grace period has expired. On each cycle the job SHALL query for candidates (`status == grace_period`, non-null `graceExpiresAt`, `graceExpiresAt <= now`, current environment) and, for each candidate, transition it to its correct terminal status:
+- `expired` if the credential's own `expiresAt` is on or before `graceExpiresAt` (`expiresAt <= graceExpiresAt` — the key's own lifetime capped it first), or
+- `revoked` if `graceExpiresAt` is before the credential's own `expiresAt` (the grace window was cut off before the key's own expiry).
+
+The run interval SHALL be configurable (`apikey.grace-revocation.*`), and the job SHALL be guarded so that a given candidate is terminated — and audited — exactly once even when multiple Hub instances run the sweep concurrently.
+
+#### Scenario: Grace period has passed, key had already reached its own expiry
+- **GIVEN** a renewed key in `status = grace_period` whose `graceExpiresAt` has passed and whose `expiresAt <= graceExpiresAt`
+- **WHEN** the scheduled job runs
+- **THEN** the key's `status` is set to `expired` in DynamoDB, `expiredAt` is set to the current time, `expiredBy` is set to `system:grace-expiration`, `revokedAt`/`revokedBy` remain `null`, and an `API_KEY_EXPIRED` audit event is emitted
+
+#### Scenario: Grace period has passed, cut off before the key's own expiry
+- **GIVEN** a renewed key in `status = grace_period` whose `graceExpiresAt` has passed and whose `graceExpiresAt < expiresAt`
+- **WHEN** the scheduled job runs
+- **THEN** the key's `status` is set to `revoked` in DynamoDB, `revokedAt` is set to the current time, `revokedBy` is set to `system:grace-revocation`, `expiredAt`/`expiredBy` remain `null`, and an `API_KEY_REVOKED` audit event is emitted
+
+#### Scenario: Grace period has not passed
+- **GIVEN** a renewed key in `status = grace_period` whose `graceExpiresAt` has not yet passed
+- **WHEN** the scheduled job runs
+- **THEN** the key is not terminated and remains `grace_period` (and continues to authenticate)
+
+#### Scenario: Idempotent re-run
+- **GIVEN** a key was already terminated (to either `expired` or `revoked`) by a previous cycle
+- **WHEN** the scheduled job runs again
+- **THEN** the key is not re-written and no duplicate audit event is emitted for it
+
+### Requirement: Termination audit events
+When the job terminates a superseded credential it SHALL emit exactly one audit event via `ApiKeyAuditLogger`, matching the terminal status assigned:
+- `API_KEY_EXPIRED`, containing at least: event type `API_KEY_EXPIRED`, `keyId` (the `jti`), `jurisdictionId`, `expiredBy` (`system:grace-expiration`), `supersededBy` (the renewing key's `jti`), and `timestamp`; or
+- `API_KEY_REVOKED`, containing at least: event type `API_KEY_REVOKED`, `keyId` (the `jti`), `jurisdictionId`, `revokedBy` (`system:grace-revocation`), `supersededBy` (the renewing key's `jti`), and `timestamp`.
+
+Neither event SHALL contain any token string or secret material.
+
+#### Scenario: Expired audit event emitted
+- **WHEN** the job marks a credential expired with `jti = K1`, `jurisdictionId = MA`, `supersededBy = K2`
+- **THEN** an `API_KEY_EXPIRED` event is emitted with `keyId = K1`, `jurisdictionId = MA`, `expiredBy = system:grace-expiration`, `supersededBy = K2`, and a timestamp, and no token or secret material
+
+#### Scenario: Revoked audit event emitted
+- **WHEN** the job revokes a credential with `jti = K1`, `jurisdictionId = MA`, `supersededBy = K2`
+- **THEN** an `API_KEY_REVOKED` event is emitted with `keyId = K1`, `jurisdictionId = MA`, `revokedBy = system:grace-revocation`, `supersededBy = K2`, and a timestamp, and no token or secret material
+
+### Requirement: Operational visibility — per-run counts
+Each execution of the job SHALL log, at a level visible in CloudWatch, the number of candidate keys evaluated, the number marked `expired`, and the number marked `revoked` in that run.
+
+#### Scenario: Counts logged each run
+- **WHEN** a cycle evaluates 5 candidate keys, marks 2 `expired`, and revokes 1
+- **THEN** the run logs a structured record indicating 5 evaluated, 2 expired, and 1 revoked

--- a/openspec/changes/igdd-3167-grace-sweeper-expired-status/tasks.md
+++ b/openspec/changes/igdd-3167-grace-sweeper-expired-status/tasks.md
@@ -1,0 +1,64 @@
+## 1. Entity
+
+- [x] 1.1 Add `expiredAt` (`Instant`, nullable) and `expiredBy` (`String`, nullable) to
+      `ApiKeyCredential`, parallel to `revokedAt`/`revokedBy` (serialized the same way, via the
+      Enhanced Client's default `InstantAsStringAttributeConverter`).
+
+## 2. Repository
+
+- [x] 2.1 Add `ApiKeyCredentialRepository.STATUS_EXPIRED = "expired"`.
+- [x] 2.2 Add `public static String resolveTerminalStatus(ApiKeyCredential credential)` — pure function:
+      `expired` if `expiresAt != null && graceExpiresAt != null && !expiresAt.isAfter(graceExpiresAt)`,
+      else `revoked` (covers the null-`expiresAt` guard case too, defaulting to current behavior).
+      Public (not package-private) so the scheduler, in a different package, can resolve the same
+      label independently.
+- [x] 2.3 Replace `buildGraceRevokeRequest` with `buildGraceTerminationRequest(tableName, env, jti,
+      terminalStatus, terminatedAt, terminatedBy)` — same conditional write shape (`status =
+      grace_period`), but sets `expiredAt`/`expiredBy` when `terminalStatus == expired`, otherwise
+      `revokedAt`/`revokedBy`, plus the `status` value itself and `updatedOn`/`updatedBy` as before.
+- [x] 2.4 Replace `revokeIfGracePeriod` with `terminateIfGracePeriod(credential, terminatedAt,
+      terminatedBy)` — resolves the terminal status internally, executes the conditional update, and
+      returns `true`/`false` exactly as the old method did (condition-failure semantics unchanged).
+
+## 3. Audit logger
+
+- [x] 3.1 Add `API_KEY_EXPIRED` and `SYSTEM_GRACE_EXPIRATION` constants to `ApiKeyAuditLogger`.
+- [x] 3.2 Add `apiKeyExpired(keyId, jurisdictionId, expiredBy, supersededBy)`, structurally parallel
+      to `apiKeyRevoked` (no token/secret material).
+
+## 4. Scheduler
+
+- [x] 4.1 In the per-candidate loop (now `terminateCredential`), compute `terminalStatus =
+      ApiKeyCredentialRepository.resolveTerminalStatus(credential)` and the matching actor
+      (`SYSTEM_GRACE_EXPIRATION` or `SYSTEM_GRACE_REVOCATION`) before writing.
+- [x] 4.2 Call `terminateIfGracePeriod(credential, now, actor)`; on a won write, emit
+      `auditLogger.apiKeyExpired(...)` or `auditLogger.apiKeyRevoked(...)` matching the resolved
+      status, then evict the local cache as before.
+- [x] 4.3 Split `CycleResult`'s single `revoked` count into `expired` and `revoked` counts; updated the
+      `GRACE_REVOCATION_RUN` log line to include both fields alongside `evaluated`.
+
+## 5. Tests
+
+- [x] 5.1 `ApiKeyCredentialRepositoryTests` — `resolveTerminalStatus`: `expiresAt < graceExpiresAt` →
+      expired; `expiresAt == graceExpiresAt` → expired (boundary); `expiresAt > graceExpiresAt` →
+      revoked; `expiresAt == null` → revoked (guard).
+- [x] 5.2 `ApiKeyCredentialRepositoryTests` — `buildGraceTerminationRequest`: expired branch sets
+      `expiredAt`/`expiredBy` and `status = expired`, and does NOT set `revokedAt`/`revokedBy`; revoked
+      branch unchanged from today's assertions (adapted to the renamed method).
+- [x] 5.3 `GracePeriodRevocationSchedulerTests` — a candidate with `expiresAt <= graceExpiresAt`
+      results in `apiKeyExpired` (not `apiKeyRevoked`) and `CycleResult.expired() == 1`; a candidate
+      with `graceExpiresAt < expiresAt` results in `apiKeyRevoked` and `CycleResult.revoked() == 1`; a
+      mixed batch produces correct per-outcome counts and audit calls; lost conditional write still
+      produces neither audit call (existing coverage, re-verified against the renamed method).
+
+**Build status:** `mvn test-compile` clean; `mvn test -Dtest=ApiKeyCredentialRepositoryTests,GracePeriodRevocationSchedulerTests` → 17 run (12 + 5), 0 failures.
+
+## Not done (out of scope, see design.md D1)
+
+- Candidate *selection* (`findGraceRevocationCandidates`/`selectGraceCandidates`) is unchanged —
+  still triggers on `graceExpiresAt <= now` only, not on `min(graceExpiresAt, expiresAt) <= now`.
+  A credential whose `expiresAt` has passed while `graceExpiresAt` is still in the future is not
+  yet a candidate at all; this change only fixes the label for credentials the sweep already
+  processes. See design.md D1 for the rationale.
+- No entity round-trip integration test for `expiredAt`/`expiredBy` (same gap noted for
+  `graceExpiresAt`/`supersededBy` in IGDD-2711 — no DynamoDB Local/Testcontainers harness in this repo).

--- a/src/main/java/gov/cdc/izgateway/dynamodb/model/ApiKeyCredential.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/model/ApiKeyCredential.java
@@ -26,6 +26,11 @@ public class ApiKeyCredential extends DynamoDbAudit implements DynamoDbEntity {
     private Instant expiresAt;
     private Instant revokedAt;
     private String revokedBy;
+    // Written by Hub's grace-period sweep (IGDD-3167) when a grace-expired credential reached its own
+    // expiresAt on/before graceExpiresAt. Mutually exclusive with revokedAt/revokedBy: a credential
+    // transitions to exactly one terminal status, so only the matching pair is ever populated.
+    private Instant expiredAt;
+    private String expiredBy;
     // Written by Config Console on renewal (IGDD-2707) onto the superseded (old) credential, which is
     // moved to status "grace_period"; read by Hub's grace-period revocation job (IGDD-2711).
     // graceExpiresAt is the instant after which the grace-period credential becomes eligible for

--- a/src/main/java/gov/cdc/izgateway/dynamodb/repository/ApiKeyCredentialRepository.java
+++ b/src/main/java/gov/cdc/izgateway/dynamodb/repository/ApiKeyCredentialRepository.java
@@ -21,8 +21,11 @@ public class ApiKeyCredentialRepository extends DynamoDbRepository<ApiKeyCredent
     /** Status of a renewed (superseded) credential during its grace window; still authenticates. */
     public static final String STATUS_GRACE_PERIOD = "grace_period";
 
-    /** Terminal status set when a credential is revoked. */
+    /** Terminal status set when a credential is cut off before reaching its own expiry. */
     public static final String STATUS_REVOKED = "revoked";
+
+    /** Terminal status set when a credential reached its own expiry (JWT {@code exp}). */
+    public static final String STATUS_EXPIRED = "expired";
 
     /** DynamoDB partition-key value (entity discriminator) for ApiKeyCredential rows. */
     private static final String ENTITY_TYPE = "ApiKeyCredential";
@@ -86,21 +89,50 @@ public class ApiKeyCredentialRepository extends DynamoDbRepository<ApiKeyCredent
     }
 
     /**
-     * Atomically revoke a credential only if it is still in {@code grace_period}, so that when
-     * multiple Hub instances run the sweep concurrently a given key is revoked — and therefore
-     * audited — exactly once. Uses a conditional DynamoDB update (condition: {@code status =
-     * "grace_period"}); the losing instances get a condition failure and do nothing.
+     * Resolve the terminal status a grace-expired credential should transition to (IGDD-3167). Per
+     * the credential state model, the JWT {@code exp} caps validity, so the effective grace end is
+     * {@code min(graceExpiresAt, expiresAt)}:
+     * <ul>
+     *   <li>{@link #STATUS_EXPIRED} if the credential reached its own {@code expiresAt} on or before
+     *       {@code graceExpiresAt} ended — the key's own lifetime capped it first.</li>
+     *   <li>{@link #STATUS_REVOKED} otherwise — the grace window was cut off before the key's own
+     *       expiry (including the defensive case of a missing {@code expiresAt}).</li>
+     * </ul>
+     * Pure function of the candidate's own fields, so callers may resolve the same label
+     * independently (e.g. to pick an audit event) without re-reading the record.
      *
-     * @param credential the grace-period candidate to revoke
-     * @param revokedAt  the revocation timestamp
-     * @param revokedBy  the revoking actor (e.g. {@code system:grace-revocation})
-     * @return {@code true} if this call performed the revocation; {@code false} if the condition
-     *         failed (another instance already revoked it, or its status is no longer grace_period)
+     * @param credential the grace-period candidate being terminated
+     * @return {@link #STATUS_EXPIRED} or {@link #STATUS_REVOKED}
      */
-    public boolean revokeIfGracePeriod(ApiKeyCredential credential, Instant revokedAt, String revokedBy) {
+    public static String resolveTerminalStatus(ApiKeyCredential credential) {
+        Instant expiresAt = credential.getExpiresAt();
+        Instant graceExpiresAt = credential.getGraceExpiresAt();
+        if (expiresAt != null && graceExpiresAt != null && !expiresAt.isAfter(graceExpiresAt)) {
+            return STATUS_EXPIRED;
+        }
+        return STATUS_REVOKED;
+    }
+
+    /**
+     * Atomically terminate a credential only if it is still in {@code grace_period}, so that when
+     * multiple Hub instances run the sweep concurrently a given key is terminated — and therefore
+     * audited — exactly once. Uses a conditional DynamoDB update (condition: {@code status =
+     * "grace_period"}); the losing instances get a condition failure and do nothing. The terminal
+     * status ({@code expired} vs {@code revoked}) is resolved from the credential's own fields via
+     * {@link #resolveTerminalStatus} (IGDD-3167).
+     *
+     * @param credential   the grace-period candidate to terminate
+     * @param terminatedAt the termination timestamp
+     * @param terminatedBy the terminating actor (e.g. {@code system:grace-expiration} or
+     *                     {@code system:grace-revocation})
+     * @return {@code true} if this call performed the termination; {@code false} if the condition
+     *         failed (another instance already terminated it, or its status is no longer grace_period)
+     */
+    public boolean terminateIfGracePeriod(ApiKeyCredential credential, Instant terminatedAt, String terminatedBy) {
+        String terminalStatus = resolveTerminalStatus(credential);
         try {
-            ddbClient.updateItem(buildGraceRevokeRequest(
-                    tableName, credential.getEnv(), credential.getJti(), revokedAt, revokedBy));
+            ddbClient.updateItem(buildGraceTerminationRequest(
+                    tableName, credential.getEnv(), credential.getJti(), terminalStatus, terminatedAt, terminatedBy));
             return true;
         } catch (ConditionalCheckFailedException e) {
             return false;
@@ -109,28 +141,34 @@ public class ApiKeyCredentialRepository extends DynamoDbRepository<ApiKeyCredent
 
     /**
      * Build the conditional {@code UpdateItem} that flips a credential from {@code grace_period} to
-     * {@code revoked}. Package-private and static so the request shape can be unit-tested without
-     * DynamoDB. ({@code status} is a DynamoDB reserved word, hence the {@code #st} name placeholder.)
+     * its resolved terminal status ({@code expired} or {@code revoked}), writing the matching
+     * timestamp/actor attribute pair ({@code expiredAt}/{@code expiredBy} or
+     * {@code revokedAt}/{@code revokedBy}) so the other pair stays {@code null}. Package-private and
+     * static so the request shape can be unit-tested without DynamoDB. ({@code status} is a DynamoDB
+     * reserved word, hence the {@code #st} name placeholder.)
      */
-    static UpdateItemRequest buildGraceRevokeRequest(String tableName, String env, String jti,
-                                                     Instant revokedAt, String revokedBy) {
+    static UpdateItemRequest buildGraceTerminationRequest(String tableName, String env, String jti,
+            String terminalStatus, Instant terminatedAt, String terminatedBy) {
+        boolean expired = STATUS_EXPIRED.equals(terminalStatus);
+        String timestampAttr = expired ? "expiredAt" : "revokedAt";
+        String actorAttr = expired ? "expiredBy" : "revokedBy";
         return UpdateItemRequest.builder()
                 .tableName(tableName)
                 .key(Map.of(
                         "entityType", AttributeValue.fromS(ENTITY_TYPE),
                         "sortKey", AttributeValue.fromS(env + "#" + jti)))
                 // Also bump the inherited audit fields (updatedOn/updatedBy) the way saveAndFlush would,
-                // so tooling/queries keyed on updatedOn see the revocation instead of the create time.
-                .updateExpression("SET #st = :revoked, revokedAt = :ra, revokedBy = :rb, "
-                        + "updatedOn = :uo, updatedBy = :rb")
+                // so tooling/queries keyed on updatedOn see the termination instead of the create time.
+                .updateExpression("SET #st = :terminal, " + timestampAttr + " = :ta, " + actorAttr + " = :tb, "
+                        + "updatedOn = :uo, updatedBy = :tb")
                 .conditionExpression("#st = :grace")
                 .expressionAttributeNames(Map.of("#st", "status"))
                 .expressionAttributeValues(Map.of(
-                        ":revoked", AttributeValue.fromS(STATUS_REVOKED),
+                        ":terminal", AttributeValue.fromS(terminalStatus),
                         ":grace", AttributeValue.fromS(STATUS_GRACE_PERIOD),
-                        ":ra", AttributeValue.fromS(revokedAt.toString()),
-                        ":rb", AttributeValue.fromS(revokedBy),
-                        ":uo", AttributeValue.fromS(AUDIT_TIMESTAMP.format(revokedAt))))
+                        ":ta", AttributeValue.fromS(terminatedAt.toString()),
+                        ":tb", AttributeValue.fromS(terminatedBy),
+                        ":uo", AttributeValue.fromS(AUDIT_TIMESTAMP.format(terminatedAt))))
                 .build();
     }
 

--- a/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyAuditLogger.java
+++ b/src/main/java/gov/cdc/izgateway/hub/security/ApiKeyAuditLogger.java
@@ -14,16 +14,20 @@ import java.time.Instant;
  * This is a dedicated, injectable component so the audit behaviour can be unit-tested independently
  * of the code paths that trigger it.</p>
  *
- * <p>Currently this emits the {@code API_KEY_REVOKED} event used by the grace-period revocation job
- * (IGDD-2711). Authentication audit events ({@code API_KEY_USED} / {@code API_KEY_AUTH_FAILED}) are
- * introduced by IGDD-2704, wired into {@link ApiKeyPrincipalProvider} in that change.</p>
+ * <p>Currently this emits the {@code API_KEY_REVOKED} and {@code API_KEY_EXPIRED} events used by the
+ * grace-period revocation job (IGDD-2711, IGDD-3167). Authentication audit events
+ * ({@code API_KEY_USED} / {@code API_KEY_AUTH_FAILED}) are introduced by IGDD-2704, wired into
+ * {@link ApiKeyPrincipalProvider} in that change.</p>
  */
 @Component
 @Slf4j
 public class ApiKeyAuditLogger {
 
-    /** Audit event type emitted when an API key is revoked. */
+    /** Audit event type emitted when an API key is revoked (cut off before its own expiry). */
     public static final String API_KEY_REVOKED = "API_KEY_REVOKED";
+
+    /** Audit event type emitted when an API key is marked expired (reached its own expiry). */
+    public static final String API_KEY_EXPIRED = "API_KEY_EXPIRED";
 
     /**
      * {@code revokedBy} value used when a credential is revoked automatically by the
@@ -31,6 +35,13 @@ public class ApiKeyAuditLogger {
      * operator-driven revocation through Config Console.
      */
     public static final String SYSTEM_GRACE_REVOCATION = "system:grace-revocation";
+
+    /**
+     * {@code expiredBy} value used when a credential is marked expired automatically by the
+     * grace-period revocation scheduled job because it reached its own {@code expiresAt} on or
+     * before its {@code graceExpiresAt} (IGDD-3167).
+     */
+    public static final String SYSTEM_GRACE_EXPIRATION = "system:grace-expiration";
 
     /**
      * Emit an {@code API_KEY_REVOKED} audit event for a credential revocation.
@@ -53,5 +64,29 @@ public class ApiKeyAuditLogger {
                 "supersededBy", supersededBy
         ).and(Markers2.append("timestamp", Instant.now().toString())),
                 "API key revoked for jurisdiction {} (keyId={}, revokedBy={})", jurisdictionId, keyId, revokedBy);
+    }
+
+    /**
+     * Emit an {@code API_KEY_EXPIRED} audit event for a credential that reached its own expiry.
+     *
+     * <p>Used by the grace-period revocation scheduled job (IGDD-3167) when a superseded
+     * credential's own {@code expiresAt} was on or before its {@code graceExpiresAt} — the JWT
+     * {@code exp} capped its validity before the grace window would have. The event carries no
+     * token or secret material.</p>
+     *
+     * @param keyId          the expired API key identifier (JWT {@code jti})
+     * @param jurisdictionId the jurisdiction the credential belonged to
+     * @param expiredBy      the identity recording the expiry (e.g. {@link #SYSTEM_GRACE_EXPIRATION})
+     * @param supersededBy   the {@code jti} of the renewed credential that superseded this one; may be {@code null}
+     */
+    public void apiKeyExpired(String keyId, String jurisdictionId, String expiredBy, String supersededBy) {
+        log.info(Markers2.append(
+                "eventType", API_KEY_EXPIRED,
+                "keyId", keyId,
+                "jurisdictionId", jurisdictionId,
+                "expiredBy", expiredBy,
+                "supersededBy", supersededBy
+        ).and(Markers2.append("timestamp", Instant.now().toString())),
+                "API key expired for jurisdiction {} (keyId={}, expiredBy={})", jurisdictionId, keyId, expiredBy);
     }
 }

--- a/src/main/java/gov/cdc/izgateway/hub/security/GracePeriodRevocationScheduler.java
+++ b/src/main/java/gov/cdc/izgateway/hub/security/GracePeriodRevocationScheduler.java
@@ -16,23 +16,26 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Scheduled job that revokes superseded API-key credentials after their grace period expires
- * (IGDD-2711, User Story 10).
+ * Scheduled job that terminates superseded API-key credentials after their grace period expires
+ * (IGDD-2711, User Story 10), recording the correct terminal status (IGDD-3167).
  *
  * <p>When Config Console renews an API key (IGDD-2707) it issues a new credential and moves the old
  * one to status {@code grace_period} with a {@code graceExpiresAt}; it keeps authenticating alongside
- * the new key during the grace window. Once {@code graceExpiresAt} passes, the old key must be revoked
- * so renewed keys do not accumulate as indefinitely-valid credentials. This job performs that sweep
- * inside Hub, reusing the credential repository and audit logger.</p>
+ * the new key during the grace window. Once {@code graceExpiresAt} passes, the old key must be
+ * terminated so renewed keys do not accumulate as indefinitely-valid credentials. Per the credential
+ * state model the effective grace end is {@code min(graceExpiresAt, expiresAt)}: a key whose own
+ * {@code expiresAt} was reached first is recorded {@code expired}; a key cut off before its own expiry
+ * is recorded {@code revoked} ({@link ApiKeyCredentialRepository#resolveTerminalStatus}). This job
+ * performs that sweep inside Hub, reusing the credential repository and audit logger.</p>
  *
  * <p>The job is gated on {@code apikey.grace-revocation.enabled} (off by default) so it can be enabled
  * per environment. Spring's scheduling infrastructure is enabled globally by {@code @EnableScheduling}
  * on the application class, independent of this bean's conditional.</p>
  *
  * <p><b>Multi-instance safety (design D5):</b> every enabled instance runs the cycle; correctness does
- * not depend on electing a single runner. Each candidate is revoked via a <em>conditional</em> write
- * ({@link ApiKeyCredentialRepository#revokeIfGracePeriod}) that only succeeds while the key is still
- * {@code grace_period}, so a given key is revoked — and audited — exactly once even under concurrent
+ * not depend on electing a single runner. Each candidate is terminated via a <em>conditional</em> write
+ * ({@link ApiKeyCredentialRepository#terminateIfGracePeriod}) that only succeeds while the key is still
+ * {@code grace_period}, so a given key is terminated — and audited — exactly once even under concurrent
  * runs. (An earlier host-ordering election was removed: the host registry can retain stale hosts, which
  * could make a lone live instance defer to a ghost and never run.) Cross-instance cache propagation is
  * intentionally not broadcast — see {@link #evictLocalCache(String)}.</p>
@@ -87,12 +90,13 @@ public class GracePeriodRevocationScheduler {
 
     /**
      * Execute one revocation cycle: find superseded credentials whose grace period has expired in
-     * this environment, revoke each, emit an audit event, and evict the local cache. Emits a
+     * this environment, terminate each to its correct status ({@code expired} or {@code revoked},
+     * IGDD-3167), emit the matching audit event, and evict the local cache. Emits a
      * {@code GRACE_REVOCATION_STARTED} log at the beginning and a {@code GRACE_REVOCATION_RUN} log on
-     * successful completion (with the number of credentials evaluated and revoked); a failure is
-     * logged as {@code GRACE_REVOCATION_FAILED} by {@link #scheduledRun()}. These three events let
-     * operations see that a run started and whether it succeeded or failed (AC #4; alarms may be
-     * layered on these log events later).
+     * successful completion (with the number of credentials evaluated, expired, and revoked); a
+     * failure is logged as {@code GRACE_REVOCATION_FAILED} by {@link #scheduledRun()}. These three
+     * events let operations see that a run started and whether it succeeded or failed (AC #4; alarms
+     * may be layered on these log events later).
      */
     CycleResult runRevocationCycle() {
         // Records are keyed by the numeric environment (e.g. "5"), matching ApiKeyPrincipalProvider's
@@ -104,16 +108,20 @@ public class GracePeriodRevocationScheduler {
         List<ApiKeyCredential> candidates = credentialRepository.findGraceRevocationCandidates(env);
 
         int evaluated = candidates.size();
+        int expired = 0;
         int revoked = 0;
         for (ApiKeyCredential credential : candidates) {
             try {
-                if (revokeCredential(credential)) {
+                String terminalStatus = terminateCredential(credential);
+                if (ApiKeyCredentialRepository.STATUS_EXPIRED.equals(terminalStatus)) {
+                    expired++;
+                } else if (ApiKeyCredentialRepository.STATUS_REVOKED.equals(terminalStatus)) {
                     revoked++;
                 }
             } catch (Exception e) {  // NOSONAR — one bad credential must not abort the rest of the sweep
                 log.warn(Markers2.append("eventType", "GRACE_REVOCATION_ERROR", "keyId", credential.getJti())
                                 .and(Markers2.append(e)),
-                        "Failed to revoke credential {}: {}", credential.getJti(), e.getMessage());
+                        "Failed to terminate credential {}: {}", credential.getJti(), e.getMessage());
             }
         }
 
@@ -121,41 +129,49 @@ public class GracePeriodRevocationScheduler {
                 "eventType", "GRACE_REVOCATION_RUN",
                 "environment", env,
                 "evaluated", evaluated,
+                "expired", expired,
                 "revoked", revoked
-        ), "Grace-period revocation cycle succeeded: evaluated={}, revoked={}", evaluated, revoked);
-        return new CycleResult(evaluated, revoked);
+        ), "Grace-period revocation cycle succeeded: evaluated={}, expired={}, revoked={}",
+                evaluated, expired, revoked);
+        return new CycleResult(evaluated, expired, revoked);
     }
 
-    /** Outcome of one revocation cycle: candidates evaluated and credentials actually revoked. */
-    record CycleResult(int evaluated, int revoked) {
+    /** Outcome of one revocation cycle: candidates evaluated, and how many were marked expired vs revoked. */
+    record CycleResult(int evaluated, int expired, int revoked) {
     }
 
     /**
-     * Revoke a single superseded credential via a conditional write (revoke only if still
-     * {@code grace_period}). On the write that actually performs the revocation, emit the
-     * {@code API_KEY_REVOKED} audit event and evict the credential from this instance's local cache.
-     * If another instance already revoked it (conditional write fails), do nothing — so the audit
-     * event fires exactly once across the fleet.
+     * Terminate a single superseded credential via a conditional write (terminate only if still
+     * {@code grace_period}). The terminal status ({@code expired} vs {@code revoked}) is resolved from
+     * the credential's own {@code expiresAt}/{@code graceExpiresAt} up front (IGDD-3167), so the actor
+     * value written and the audit event emitted match the write the repository performs. On the write
+     * that actually performs the termination, emit the matching audit event and evict the credential
+     * from this instance's local cache. If another instance already terminated it (conditional write
+     * fails), do nothing — so the audit event fires exactly once across the fleet.
      *
-     * @param credential the grace-expired candidate to revoke
-     * @return {@code true} if this call performed the revocation; {@code false} otherwise
+     * @param credential the grace-expired candidate to terminate
+     * @return the terminal status applied ({@link ApiKeyCredentialRepository#STATUS_EXPIRED} or
+     *         {@link ApiKeyCredentialRepository#STATUS_REVOKED}) if this call performed the
+     *         termination; {@code null} if the conditional write lost
      */
-    private boolean revokeCredential(ApiKeyCredential credential) {
-        boolean revoked = credentialRepository.revokeIfGracePeriod(
-                credential, Instant.now(), ApiKeyAuditLogger.SYSTEM_GRACE_REVOCATION);
-        if (!revoked) {
-            return false;
+    private String terminateCredential(ApiKeyCredential credential) {
+        String terminalStatus = ApiKeyCredentialRepository.resolveTerminalStatus(credential);
+        boolean expired = ApiKeyCredentialRepository.STATUS_EXPIRED.equals(terminalStatus);
+        String actor = expired ? ApiKeyAuditLogger.SYSTEM_GRACE_EXPIRATION : ApiKeyAuditLogger.SYSTEM_GRACE_REVOCATION;
+
+        boolean won = credentialRepository.terminateIfGracePeriod(credential, Instant.now(), actor);
+        if (!won) {
+            return null;
         }
 
         String jti = credential.getJti();
-        auditLogger.apiKeyRevoked(
-                jti,
-                credential.getJurisdictionId(),
-                ApiKeyAuditLogger.SYSTEM_GRACE_REVOCATION,
-                credential.getSupersededBy()
-        );
+        if (expired) {
+            auditLogger.apiKeyExpired(jti, credential.getJurisdictionId(), actor, credential.getSupersededBy());
+        } else {
+            auditLogger.apiKeyRevoked(jti, credential.getJurisdictionId(), actor, credential.getSupersededBy());
+        }
         evictLocalCache(jti);
-        return true;
+        return terminalStatus;
     }
 
     /**

--- a/src/test/java/gov/cdc/izgateway/dynamodb/repository/ApiKeyCredentialRepositoryTests.java
+++ b/src/test/java/gov/cdc/izgateway/dynamodb/repository/ApiKeyCredentialRepositoryTests.java
@@ -12,8 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the grace-revocation selection predicate
- * ({@link ApiKeyCredentialRepository#selectGraceCandidates}) and the conditional revoke-request
- * builder ({@link ApiKeyCredentialRepository#buildGraceRevokeRequest}). The DynamoDB calls
+ * ({@link ApiKeyCredentialRepository#selectGraceCandidates}), the terminal-status resolver
+ * ({@link ApiKeyCredentialRepository#resolveTerminalStatus}), and the conditional termination-request
+ * builder ({@link ApiKeyCredentialRepository#buildGraceTerminationRequest}). The DynamoDB calls
  * themselves are thin delegations covered by integration testing; these tests pin the pure logic.
  */
 class ApiKeyCredentialRepositoryTests {
@@ -75,25 +76,71 @@ class ApiKeyCredentialRepositoryTests {
     }
 
     @Test
-    void buildGraceRevokeRequest_targetsCorrectKeyWithGracePeriodCondition() {
-        Instant revokedAt = Instant.parse("2026-07-20T15:00:00Z");
-        UpdateItemRequest req = ApiKeyCredentialRepository.buildGraceRevokeRequest(
-                "izgateway-dev-test", "5", "jti-abc", revokedAt, "system:grace-revocation");
+    void buildGraceTerminationRequest_revokedBranch_targetsCorrectKeyWithGracePeriodCondition() {
+        Instant terminatedAt = Instant.parse("2026-07-20T15:00:00Z");
+        UpdateItemRequest req = ApiKeyCredentialRepository.buildGraceTerminationRequest(
+                "izgateway-dev-test", "5", "jti-abc", "revoked", terminatedAt, "system:grace-revocation");
 
         assertThat(req.tableName()).isEqualTo("izgateway-dev-test");
         // Targets the exact item: partition entityType=ApiKeyCredential, sort key {env}#{jti}.
         assertThat(req.key().get("entityType").s()).isEqualTo("ApiKeyCredential");
         assertThat(req.key().get("sortKey").s()).isEqualTo("5#jti-abc");
-        // Only writes when still grace_period → exactly-once revoke across concurrent instances.
+        // Only writes when still grace_period → exactly-once termination across concurrent instances.
         assertThat(req.conditionExpression()).isEqualTo("#st = :grace");
         assertThat(req.expressionAttributeNames()).containsEntry("#st", "status");
         assertThat(req.expressionAttributeValues().get(":grace").s()).isEqualTo("grace_period");
-        assertThat(req.expressionAttributeValues().get(":revoked").s()).isEqualTo("revoked");
-        // revokedAt is the ISO-8601 'Z' Instant form; updatedOn uses the DynamoDbAudit Date form
+        assertThat(req.expressionAttributeValues().get(":terminal").s()).isEqualTo("revoked");
+        // Writes revokedAt/revokedBy for the revoked branch; expiredAt/expiredBy stay untouched.
+        assertThat(req.updateExpression()).contains("revokedAt = :ta", "revokedBy = :tb")
+                .doesNotContain("expiredAt", "expiredBy");
+        // terminatedAt is the ISO-8601 'Z' Instant form; updatedOn uses the DynamoDbAudit Date form
         // (millis + numeric +0000 offset) so it round-trips through the Enhanced Client's converter.
-        assertThat(req.expressionAttributeValues().get(":ra").s()).isEqualTo("2026-07-20T15:00:00Z");
-        assertThat(req.expressionAttributeValues().get(":rb").s()).isEqualTo("system:grace-revocation");
-        assertThat(req.updateExpression()).contains("updatedOn = :uo", "updatedBy = :rb");
+        assertThat(req.expressionAttributeValues().get(":ta").s()).isEqualTo("2026-07-20T15:00:00Z");
+        assertThat(req.expressionAttributeValues().get(":tb").s()).isEqualTo("system:grace-revocation");
+        assertThat(req.updateExpression()).contains("updatedOn = :uo", "updatedBy = :tb");
         assertThat(req.expressionAttributeValues().get(":uo").s()).isEqualTo("2026-07-20T15:00:00.000+0000");
+    }
+
+    @Test
+    void buildGraceTerminationRequest_expiredBranch_writesExpiredFieldsOnly() {
+        Instant terminatedAt = Instant.parse("2026-07-20T15:00:00Z");
+        UpdateItemRequest req = ApiKeyCredentialRepository.buildGraceTerminationRequest(
+                "izgateway-dev-test", "5", "jti-abc", "expired", terminatedAt, "system:grace-expiration");
+
+        assertThat(req.expressionAttributeValues().get(":terminal").s()).isEqualTo("expired");
+        assertThat(req.updateExpression()).contains("expiredAt = :ta", "expiredBy = :tb")
+                .doesNotContain("revokedAt", "revokedBy");
+        assertThat(req.expressionAttributeValues().get(":tb").s()).isEqualTo("system:grace-expiration");
+    }
+
+    private ApiKeyCredential credWithExpiry(Instant expiresAt, Instant graceExpiresAt) {
+        ApiKeyCredential c = new ApiKeyCredential();
+        c.setExpiresAt(expiresAt);
+        c.setGraceExpiresAt(graceExpiresAt);
+        return c;
+    }
+
+    @Test
+    void resolveTerminalStatus_expiresBeforeGraceExpiry_isExpired() {
+        ApiKeyCredential c = credWithExpiry(NOW.minus(1, ChronoUnit.HOURS), NOW);
+        assertThat(ApiKeyCredentialRepository.resolveTerminalStatus(c)).isEqualTo("expired");
+    }
+
+    @Test
+    void resolveTerminalStatus_expiresEqualsGraceExpiry_isExpired() {
+        ApiKeyCredential c = credWithExpiry(NOW, NOW);
+        assertThat(ApiKeyCredentialRepository.resolveTerminalStatus(c)).isEqualTo("expired");
+    }
+
+    @Test
+    void resolveTerminalStatus_graceExpiryBeforeExpires_isRevoked() {
+        ApiKeyCredential c = credWithExpiry(NOW.plus(1, ChronoUnit.HOURS), NOW);
+        assertThat(ApiKeyCredentialRepository.resolveTerminalStatus(c)).isEqualTo("revoked");
+    }
+
+    @Test
+    void resolveTerminalStatus_nullExpiresAt_defaultsToRevoked() {
+        ApiKeyCredential c = credWithExpiry(null, NOW);
+        assertThat(ApiKeyCredentialRepository.resolveTerminalStatus(c)).isEqualTo("revoked");
     }
 }

--- a/src/test/java/gov/cdc/izgateway/hub/security/GracePeriodRevocationSchedulerTests.java
+++ b/src/test/java/gov/cdc/izgateway/hub/security/GracePeriodRevocationSchedulerTests.java
@@ -22,8 +22,10 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link GracePeriodRevocationScheduler}. The repository is mocked; the scheduler
- * delegates the atomic "revoke only if still grace_period" decision to
- * {@link ApiKeyCredentialRepository#revokeIfGracePeriod}, and only audits/evicts when that write wins.
+ * delegates the atomic "terminate only if still grace_period" decision to
+ * {@link ApiKeyCredentialRepository#terminateIfGracePeriod}, and only audits/evicts when that write
+ * wins, emitting {@code apiKeyExpired} or {@code apiKeyRevoked} depending on the resolved terminal
+ * status (IGDD-3167: {@code expiresAt <= graceExpiresAt} → expired, else revoked).
  */
 @ExtendWith(MockitoExtension.class)
 class GracePeriodRevocationSchedulerTests {
@@ -31,6 +33,7 @@ class GracePeriodRevocationSchedulerTests {
     private static final String JTI = "00000000-0000-0000-0000-000000000099";
     private static final String NEW_JTI = "00000000-0000-0000-0000-0000000000aa";
     private static final String JURISDICTION = "MA";
+    private static final Instant GRACE_EXPIRES_AT = Instant.parse("2026-07-20T00:00:00Z");
 
     @Mock private ApiKeyCredentialRepository credentialRepository;
     @Mock private ApiKeyAuditLogger auditLogger;
@@ -43,44 +46,80 @@ class GracePeriodRevocationSchedulerTests {
         scheduler = new GracePeriodRevocationScheduler(credentialRepository, auditLogger, apiKeyPrincipalProvider);
     }
 
-    private ApiKeyCredential credential(String jti, String supersededBy) {
+    /** A grace-period candidate cut off before its own expiry (expiresAt after graceExpiresAt) → revoked. */
+    private ApiKeyCredential revokedCandidate(String jti, String supersededBy) {
         ApiKeyCredential c = new ApiKeyCredential();
         c.setJti(jti);
         c.setJurisdictionId(JURISDICTION);
         c.setSupersededBy(supersededBy);
+        c.setGraceExpiresAt(GRACE_EXPIRES_AT);
+        c.setExpiresAt(GRACE_EXPIRES_AT.plusSeconds(3600));
+        return c;
+    }
+
+    /** A grace-period candidate that reached its own expiry on/before graceExpiresAt → expired. */
+    private ApiKeyCredential expiredCandidate(String jti, String supersededBy) {
+        ApiKeyCredential c = new ApiKeyCredential();
+        c.setJti(jti);
+        c.setJurisdictionId(JURISDICTION);
+        c.setSupersededBy(supersededBy);
+        c.setGraceExpiresAt(GRACE_EXPIRES_AT);
+        c.setExpiresAt(GRACE_EXPIRES_AT.minusSeconds(3600));
         return c;
     }
 
     @Test
-    void wonConditionalWrite_isAuditedAndEvicted() {
-        ApiKeyCredential graceKey = credential(JTI, NEW_JTI);
+    void wonConditionalWrite_revokedOutcome_isAuditedAndEvicted() {
+        ApiKeyCredential graceKey = revokedCandidate(JTI, NEW_JTI);
         when(credentialRepository.findGraceRevocationCandidates(anyString())).thenReturn(List.of(graceKey));
-        when(credentialRepository.revokeIfGracePeriod(eq(graceKey), any(Instant.class),
+        when(credentialRepository.terminateIfGracePeriod(eq(graceKey), any(Instant.class),
                 eq(ApiKeyAuditLogger.SYSTEM_GRACE_REVOCATION))).thenReturn(true);
 
         GracePeriodRevocationScheduler.CycleResult result = scheduler.runRevocationCycle();
 
         assertThat(result.evaluated()).isEqualTo(1);
         assertThat(result.revoked()).isEqualTo(1);
+        assertThat(result.expired()).isZero();
         // Audit event carries the superseding jti; local cache evicted.
         verify(auditLogger).apiKeyRevoked(eq(JTI), eq(JURISDICTION),
                 eq(ApiKeyAuditLogger.SYSTEM_GRACE_REVOCATION), eq(NEW_JTI));
+        verify(auditLogger, never()).apiKeyExpired(any(), any(), any(), any());
         verify(apiKeyPrincipalProvider).evictCredential(JTI);
-        // Revocation goes through the conditional write only — never the plain store() put.
+        // Termination goes through the conditional write only — never the plain store() put.
+        verify(credentialRepository, never()).store(any());
+    }
+
+    @Test
+    void wonConditionalWrite_expiredOutcome_isAuditedAndEvicted() {
+        ApiKeyCredential graceKey = expiredCandidate(JTI, NEW_JTI);
+        when(credentialRepository.findGraceRevocationCandidates(anyString())).thenReturn(List.of(graceKey));
+        when(credentialRepository.terminateIfGracePeriod(eq(graceKey), any(Instant.class),
+                eq(ApiKeyAuditLogger.SYSTEM_GRACE_EXPIRATION))).thenReturn(true);
+
+        GracePeriodRevocationScheduler.CycleResult result = scheduler.runRevocationCycle();
+
+        assertThat(result.evaluated()).isEqualTo(1);
+        assertThat(result.expired()).isEqualTo(1);
+        assertThat(result.revoked()).isZero();
+        verify(auditLogger).apiKeyExpired(eq(JTI), eq(JURISDICTION),
+                eq(ApiKeyAuditLogger.SYSTEM_GRACE_EXPIRATION), eq(NEW_JTI));
+        verify(auditLogger, never()).apiKeyRevoked(any(), any(), any(), any());
+        verify(apiKeyPrincipalProvider).evictCredential(JTI);
         verify(credentialRepository, never()).store(any());
     }
 
     @Test
     void lostConditionalWrite_noAuditNoEvict() {
-        // Another instance already revoked it: the conditional write fails → no audit, no eviction.
-        ApiKeyCredential graceKey = credential(JTI, NEW_JTI);
+        // Another instance already terminated it: the conditional write fails → no audit, no eviction.
+        ApiKeyCredential graceKey = revokedCandidate(JTI, NEW_JTI);
         when(credentialRepository.findGraceRevocationCandidates(anyString())).thenReturn(List.of(graceKey));
-        when(credentialRepository.revokeIfGracePeriod(any(), any(), any())).thenReturn(false);
+        when(credentialRepository.terminateIfGracePeriod(any(), any(), any())).thenReturn(false);
 
         GracePeriodRevocationScheduler.CycleResult result = scheduler.runRevocationCycle();
 
         assertThat(result.evaluated()).isEqualTo(1);
         assertThat(result.revoked()).isZero();
+        assertThat(result.expired()).isZero();
         verifyNoInteractions(auditLogger, apiKeyPrincipalProvider);
         verify(credentialRepository, never()).store(any());
     }
@@ -93,31 +132,34 @@ class GracePeriodRevocationSchedulerTests {
 
         assertThat(result.evaluated()).isZero();
         assertThat(result.revoked()).isZero();
-        verify(credentialRepository, never()).revokeIfGracePeriod(any(), any(), any());
+        assertThat(result.expired()).isZero();
+        verify(credentialRepository, never()).terminateIfGracePeriod(any(), any(), any());
         verifyNoInteractions(auditLogger, apiKeyPrincipalProvider);
     }
 
     @Test
-    void multipleCandidates_auditsOnlyTheOnesWon() {
-        ApiKeyCredential won1 = credential("jti-won-1", "new-1");
-        ApiKeyCredential lost = credential("jti-lost", "new-x");
-        ApiKeyCredential won2 = credential("jti-won-2", "new-2");
+    void multipleCandidates_auditsOnlyTheOnesWonWithCorrectOutcome() {
+        ApiKeyCredential wonRevoked = revokedCandidate("jti-won-revoked", "new-1");
+        ApiKeyCredential lost = revokedCandidate("jti-lost", "new-x");
+        ApiKeyCredential wonExpired = expiredCandidate("jti-won-expired", "new-2");
         when(credentialRepository.findGraceRevocationCandidates(anyString()))
-                .thenReturn(List.of(won1, lost, won2));
-        when(credentialRepository.revokeIfGracePeriod(eq(won1), any(), any())).thenReturn(true);
-        when(credentialRepository.revokeIfGracePeriod(eq(lost), any(), any())).thenReturn(false);
-        when(credentialRepository.revokeIfGracePeriod(eq(won2), any(), any())).thenReturn(true);
+                .thenReturn(List.of(wonRevoked, lost, wonExpired));
+        when(credentialRepository.terminateIfGracePeriod(eq(wonRevoked), any(), any())).thenReturn(true);
+        when(credentialRepository.terminateIfGracePeriod(eq(lost), any(), any())).thenReturn(false);
+        when(credentialRepository.terminateIfGracePeriod(eq(wonExpired), any(), any())).thenReturn(true);
 
         GracePeriodRevocationScheduler.CycleResult result = scheduler.runRevocationCycle();
 
-        // 3 evaluated; only the 2 that won the conditional write are counted as revoked.
+        // 3 evaluated; only the 2 that won the conditional write are counted, split by outcome.
         assertThat(result.evaluated()).isEqualTo(3);
-        assertThat(result.revoked()).isEqualTo(2);
-        verify(auditLogger).apiKeyRevoked(eq("jti-won-1"), anyString(), anyString(), eq("new-1"));
-        verify(auditLogger).apiKeyRevoked(eq("jti-won-2"), anyString(), anyString(), eq("new-2"));
+        assertThat(result.revoked()).isEqualTo(1);
+        assertThat(result.expired()).isEqualTo(1);
+        verify(auditLogger).apiKeyRevoked(eq("jti-won-revoked"), anyString(), anyString(), eq("new-1"));
+        verify(auditLogger).apiKeyExpired(eq("jti-won-expired"), anyString(), anyString(), eq("new-2"));
         verify(auditLogger, never()).apiKeyRevoked(eq("jti-lost"), anyString(), anyString(), anyString());
-        verify(apiKeyPrincipalProvider).evictCredential("jti-won-1");
-        verify(apiKeyPrincipalProvider).evictCredential("jti-won-2");
+        verify(auditLogger, never()).apiKeyExpired(eq("jti-lost"), anyString(), anyString(), anyString());
+        verify(apiKeyPrincipalProvider).evictCredential("jti-won-revoked");
+        verify(apiKeyPrincipalProvider).evictCredential("jti-won-expired");
         verify(apiKeyPrincipalProvider, never()).evictCredential("jti-lost");
     }
 }


### PR DESCRIPTION
GracePeriodRevocationScheduler previously flipped every grace-expired credential to revoked regardless of cause. Per the credential state model the effective grace end is min(graceExpiresAt, expiresAt): a key that reached its own expiry should be recorded expired, and only a key cut off before its own expiry should be recorded revoked, so the persisted status and audit trail reflect why the key stopped being usable.